### PR TITLE
ENH: add Python logger hook for PCDS-wide logging system

### DIFF
--- a/pcdsutils/__init__.py
+++ b/pcdsutils/__init__.py
@@ -1,3 +1,7 @@
 from ._version import get_versions
+from . import log
+
 __version__ = get_versions()['version']
 del get_versions
+
+__all__ = ['log']

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -68,7 +68,7 @@ _CURRENT_HANDLER = None
 class _PassthroughStreamHandler(logging.handlers.SocketHandler):
     def makePickle(self, record):
         'Overrides super().makePickle'
-        return record.encode('utf-8')
+        return record.encode('utf-8') + b'\n'
 
 
 class _PassthroughDatagramHandler(logging.handlers.DatagramHandler):

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -1,0 +1,236 @@
+import copy
+import json
+import logging
+import os
+import queue as queue_module
+import sys
+
+import logging.handlers
+
+# The special logger:
+logger = logging.getLogger('pcds-logging')
+
+DEFAULT_LOG_HOST = os.environ.get('PCDS_LOG_HOST', 'ctl-tst-log01.pcdsn')
+DEFAULT_LOG_PORT = int(os.environ.get('PCDS_LOG_PORT', 54320))
+DEFAULT_LOG_PROTO = os.environ.get('PCDS_LOG_PROTO', 'udp')
+DEFAULT_LOG_USES_UDP = (DEFAULT_LOG_PROTO.lower() == 'udp')
+
+_LOGGER_SCHEMA_VERSION = 0
+
+_LOGGER_ALLOWED_KEYS = {
+    # 'args',
+    # 'created',
+    # 'exc_info',
+    'exc_text',
+    'filename',
+    # 'funcName',
+    # 'levelname',
+    # 'levelno',
+    'lineno',
+    # 'message',
+    # 'module',
+    # 'msecs',
+    'msg',
+    # 'name',
+    'pathname',
+    # 'process',
+    'processName',
+    # 'relativeCreated',
+    # 'stack_info',
+    # 'thread',
+    'threadName',
+
+    # Ones our schema specifies:
+    'schema',
+    'source',
+    'versions',
+}
+
+_LOGGER_KEY_RENAMES = {
+    'created': 'ts',  # created time -> timestamp (ts)
+    'levelname': 'severity',
+    'processName': 'process_name',
+    'threadName': 'thread_name',
+}
+
+_CURRENT_HANDLER = None
+
+
+class _PassthroughStreamHandler(logging.handlers.SocketHandler):
+    def makePickle(self, record):
+        'Overrides super().makePickle'
+        return record.encode('utf-8')
+
+
+class _PassthroughDatagramHandler(logging.handlers.DatagramHandler):
+    def makePickle(self, record):
+        'Overrides super().makePickle'
+        return record.encode('utf-8')
+
+
+class _LogQueueListener(logging.handlers.QueueListener):
+    'A log handler which listens in a separate thread for queued records'
+
+
+def _get_module_versions():
+    'Yields module version tuples: (module_name, module_version)'
+    def fix_version(version):
+        if isinstance(version, bytes):
+            # _curses, for example
+            return version.decode('utf-8')
+        if not isinstance(version, str):
+            # Some may have incorrectly specified version as a tuple
+            return '.'.join([str(part) for part in version])
+        return version
+
+    for name, module in sys.modules.items():
+        if hasattr(module, '__version__'):
+            try:
+                version = fix_version(module.__version__)
+            except Exception:
+                version = repr(module.__version__)
+            yield name, version
+
+
+def create_log_dictionary_from_record(record: logging.LogRecord) -> dict:
+    '''
+    Create a PCDS logging-compliant dictionary from a given logging.LogRecord
+
+    Ensure that exceptions have been formatted with `logging.Handler` prior to
+    calling this function.
+
+    Parameters
+    ----------
+    record : logging.LogRecord or dict
+        The record to interpret
+
+    Returns
+    -------
+    dict
+        The ready-to-be-JSON'd record dictionary
+    '''
+    # Shallow-copy the record dictionary
+    ret = dict(record if isinstance(record, dict) else vars(record))
+
+    ret['schema'] = f'python-event-{_LOGGER_SCHEMA_VERSION}'
+    ret['source'] = '{module}.{funcName}:{lineno}'.format(**ret)
+    ret['versions'] = dict(_get_module_versions())
+    ret['pathname'] = str(os.path.abspath(ret['pathname']))
+
+    for from_, to in _LOGGER_KEY_RENAMES.items():
+        ret[to] = ret.pop(from_)
+
+    other_keys = set(ret) - _LOGGER_ALLOWED_KEYS
+    for key in other_keys:
+        ret.pop(key)
+
+    return ret
+
+
+class _JsonLogQueueHandler(logging.handlers.QueueHandler):
+    'Logging handler which pushes `logging.LogRecord`s to a separate thread'
+    def __init__(self, *handlers, queue=None):
+        queue = queue or queue_module.Queue()
+        super().__init__(queue)
+        self.listener = _LogQueueListener(self.queue)
+        self.listener.handlers = list(handlers)
+        self.listener.start()
+
+    def prepare(self, record):
+        'Overrides QueueHandle prepare'
+        # Avoid modifying the record in-place; other handlers will be affected
+        record = copy.copy(record)
+        if record.exc_info:
+            # Format the traceback into record.exc_text:
+            _ = self.format(record)
+
+        # Send along the serialized JSON to any downstream handlers, at least
+        # `self.listener`
+        return json.dumps(create_log_dictionary_from_record(record))
+
+
+def configure_pcds_logging(
+        file=sys.stdout, *,
+        log_host=DEFAULT_LOG_HOST, log_port=DEFAULT_LOG_PORT,
+        protocol=DEFAULT_LOG_PROTO,
+        level='DEBUG'):
+    """
+    Set a new handler on the ``logging.getLogger('pcds-logging')`` logger.
+
+    If this is called more than once, the handler from the previous invocation
+    is removed (if still present) and replaced.
+
+    Parameters
+    ----------
+    log_host : str, optional
+        The log host server host. Defaults to the environment variable
+        PCDS_LOG_HOST.
+
+    log_port : int, optional
+        The log host server port. Defaults to the environment variable
+        PCDS_LOG_PORT.
+
+    protocol : {'tcp', 'udp'}
+        Use UDP or TCP as the transport protocol. Defaults to the environment
+        variable PCDS_LOG_PROTO.
+
+    level : str or int
+        Minimum logging level, given as string or corresponding integer.
+        Default is 'DEBUG'.
+
+    Returns
+    -------
+    handler : logging.Handler
+        The handler, which has already been added to the 'pcds-logging' logger.
+    """
+    global _CURRENT_HANDLER
+
+    handler_cls = {
+        'udp': _PassthroughDatagramHandler,
+        'tcp': _PassthroughStreamHandler
+    }[protocol.lower()]
+
+    socket_handler = handler_cls(log_host, log_port)
+
+    handler = _JsonLogQueueHandler(socket_handler)
+
+    levelno = validate_log_level(level)
+    handler.setLevel(levelno)
+
+    # handler.setFormatter(_LogFormatter(PLAIN_LOG_FORMAT))
+    if _CURRENT_HANDLER in logger.handlers:
+        logger.removeHandler(_CURRENT_HANDLER)
+        _CURRENT_HANDLER.listener.stop()
+
+    logger.addHandler(handler)
+    _CURRENT_HANDLER = handler
+
+    if logger.getEffectiveLevel() > levelno:
+        logger.setLevel(levelno)
+    return handler
+
+
+def validate_log_level(level) -> int:
+    '''
+    Return a int for level comparison
+    '''
+    if isinstance(level, int):
+        levelno = level
+    elif isinstance(level, str):
+        levelno = logging.getLevelName(level)
+
+    if isinstance(levelno, int):
+        return levelno
+    else:
+        raise ValueError("Log level is invalid")
+
+
+def get_handler():
+    """
+    Return the handler configured by the most recent call to
+    :func:`configure_pcds_logging`.
+
+    If :func:`configure_pcds_logging` has not yet been called, this returns
+    ``None``.
+    """
+    return _CURRENT_HANDLER

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -98,7 +98,7 @@ def _get_module_versions():
                 version = fix_version(module.__version__)
             except Exception:
                 version = repr(module.__version__)
-            yield name, version
+            yield name.replace('.', '_'), version
 
 
 def _get_module_version_dict():

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -13,7 +13,6 @@ logger = logging.getLogger('pcds-logging')
 DEFAULT_LOG_HOST = os.environ.get('PCDS_LOG_HOST', 'ctl-tst-log01.pcdsn')
 DEFAULT_LOG_PORT = int(os.environ.get('PCDS_LOG_PORT', 54320))
 DEFAULT_LOG_PROTO = os.environ.get('PCDS_LOG_PROTO', 'udp')
-DEFAULT_LOG_USES_UDP = (DEFAULT_LOG_PROTO.lower() == 'udp')
 
 _LOGGER_SCHEMA_VERSION = 0
 

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import queue as queue_module
+import socket
 import sys
 
 import logging.handlers
@@ -43,6 +44,8 @@ _LOGGER_ALLOWED_KEYS = {
     'schema',
     'source',
     'versions',
+    'hostname',
+    'host_info',
 }
 
 _LOGGER_KEY_RENAMES = {
@@ -52,6 +55,7 @@ _LOGGER_KEY_RENAMES = {
     'threadName': 'thread_name',
 }
 
+_SYSTEM_UNAME_INFO = os.uname()
 _CURRENT_HANDLER = None
 
 
@@ -115,6 +119,12 @@ def create_log_dictionary_from_record(record: logging.LogRecord) -> dict:
     ret['source'] = '{module}.{funcName}:{lineno}'.format(**ret)
     ret['versions'] = dict(_get_module_versions())
     ret['pathname'] = str(os.path.abspath(ret['pathname']))
+    ret['hostname'] = socket.gethostname()
+    ret['host_info'] = {'sysname': _SYSTEM_UNAME_INFO.sysname,
+                        'release': _SYSTEM_UNAME_INFO.release,
+                        'version': _SYSTEM_UNAME_INFO.version,
+                        'machine': _SYSTEM_UNAME_INFO.machine,
+                        }
 
     for from_, to in _LOGGER_KEY_RENAMES.items():
         ret[to] = ret.pop(from_)

--- a/pcdsutils/tests/test_logging.py
+++ b/pcdsutils/tests/test_logging.py
@@ -1,0 +1,22 @@
+import logging
+
+import pcdsutils
+
+
+logging.basicConfig()
+
+
+def test_smoke_logging():
+    pcdsutils.log.configure_pcds_logging(log_host='127.0.0.1')
+    # logger = logging.getLogger('pcds-logging')
+    logger = pcdsutils.log.logger
+
+    logger.warning('test1')
+
+    try:
+        testabcd  # noqa
+    except Exception:
+        logger.exception('test2')
+
+    import time
+    time.sleep(0.1)

--- a/pcdsutils/tests/test_logging.py
+++ b/pcdsutils/tests/test_logging.py
@@ -2,6 +2,7 @@ import json
 import logging
 import socket
 import threading
+import pprint
 import queue
 
 import pytest
@@ -17,6 +18,7 @@ LOGGER = pcdsutils.log.logger
 @pytest.fixture
 def udp_socket():
     return socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
 
 @pytest.fixture
 def udp_log_listener(udp_socket):
@@ -46,7 +48,8 @@ def udp_listening_port(udp_socket):
     return udp_socket.getsockname()[1]
 
 
-def test_log_warning_udp(udp_listening_port: int, udp_log_listener: queue.Queue):
+def test_log_warning_udp(udp_listening_port: int,
+                         udp_log_listener: queue.Queue):
     pcdsutils.log.configure_pcds_logging(log_host='127.0.0.1',
                                          log_port=udp_listening_port,
                                          protocol='udp')
@@ -54,11 +57,12 @@ def test_log_warning_udp(udp_listening_port: int, udp_log_listener: queue.Queue)
     LOGGER.warning('test1')
     msg, addr = udp_log_listener.get()
     log_dict = json.loads(msg)
-    print('log', log_dict)
+    pprint.pprint(log_dict)
     assert log_dict['msg'] == 'test1'
 
 
-def test_log_exception_udp(udp_listening_port: int, udp_log_listener: queue.Queue):
+def test_log_exception_udp(udp_listening_port: int,
+                           udp_log_listener: queue.Queue):
     pcdsutils.log.configure_pcds_logging(log_host='127.0.0.1',
                                          log_port=udp_listening_port,
                                          protocol='udp')
@@ -69,7 +73,7 @@ def test_log_exception_udp(udp_listening_port: int, udp_log_listener: queue.Queu
 
     msg, addr = udp_log_listener.get()
     log_dict = json.loads(msg)
-    print('log', log_dict)
+    pprint.pprint(log_dict)
 
     assert log_dict['msg'] == 'test2'
     assert 'testabcd' in log_dict['exc_text']

--- a/pcdsutils/tests/test_logging.py
+++ b/pcdsutils/tests/test_logging.py
@@ -1,22 +1,75 @@
+import json
 import logging
+import socket
+import threading
+import queue
 
+import pytest
 import pcdsutils
 
 
 logging.basicConfig()
 
 
-def test_smoke_logging():
-    pcdsutils.log.configure_pcds_logging(log_host='127.0.0.1')
-    # logger = logging.getLogger('pcds-logging')
-    logger = pcdsutils.log.logger
+LOGGER = pcdsutils.log.logger
 
-    logger.warning('test1')
 
+@pytest.fixture
+def udp_socket():
+    return socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+@pytest.fixture
+def udp_log_listener(udp_socket):
+    received = queue.Queue()
+    ev = threading.Event()
+    try:
+        def listener_thread():
+            while not ev.is_set():
+                try:
+                    data = udp_socket.recvfrom(4096)
+                except socket.timeout:
+                    ...
+                else:
+                    received.put(data)
+            udp_socket.close()
+
+        threading.Thread(target=listener_thread, daemon=True).start()
+        yield received
+    finally:
+        ev.set()
+
+
+@pytest.fixture
+def udp_listening_port(udp_socket):
+    udp_socket.settimeout(0.1)
+    udp_socket.bind(('127.0.0.1', 0))
+    return udp_socket.getsockname()[1]
+
+
+def test_log_warning_udp(udp_listening_port: int, udp_log_listener: queue.Queue):
+    pcdsutils.log.configure_pcds_logging(log_host='127.0.0.1',
+                                         log_port=udp_listening_port,
+                                         protocol='udp')
+
+    LOGGER.warning('test1')
+    msg, addr = udp_log_listener.get()
+    log_dict = json.loads(msg)
+    print('log', log_dict)
+    assert log_dict['msg'] == 'test1'
+
+
+def test_log_exception_udp(udp_listening_port: int, udp_log_listener: queue.Queue):
+    pcdsutils.log.configure_pcds_logging(log_host='127.0.0.1',
+                                         log_port=udp_listening_port,
+                                         protocol='udp')
     try:
         testabcd  # noqa
     except Exception:
-        logger.exception('test2')
+        LOGGER.exception('test2')
 
-    import time
-    time.sleep(0.1)
+    msg, addr = udp_log_listener.get()
+    log_dict = json.loads(msg)
+    print('log', log_dict)
+
+    assert log_dict['msg'] == 'test2'
+    assert 'testabcd' in log_dict['exc_text']


### PR DESCRIPTION
A preliminary implementation, with a bit of code borrowed from caproto (aka the project with the most effort put into logging).

Examples of what these dictionaries look like:

<details>

pcdsutils/tests/test_logging.py::test_log_warning_udp

```
 {'exc_text': None,
 'filename': 'test_logging.py',
 'lineno': 57,
 'msg': 'test1',
 'pathname': '/Users/klauer/docs/Repos/pcdsutils/pcdsutils/tests/test_logging.py',
 'schema': 'python-event-0',
 'source': 'test_logging.test_log_warning_udp:57',
 'versions': {'_csv': '1.0',
              '_decimal': '1.70',
              '_pytest': '5.3.4',
              'argparse': '1.1',
              'attr': '19.3.0',
              'coverage': '5.0.3',
              'coverage.jsonreport': '5.0.3',
              'coverage.sqldata': '5.0.3',
              'coverage.version': '5.0.3',
              'coverage.xmlreport': '5.0.3',
              'csv': '1.0',
              'decimal': '1.70',
              'importlib_metadata': '1.4.0',
              'json': '2.0.9',
              'logging': '0.5.1.2',
              'more_itertools': '8.1.0',
              'optparse': '1.5.3',
              'packaging': '20.0',
              'packaging.__about__': '20.0',
              'pcdsutils': '0.0.0+2.g2942a19.dirty',
              'platform': '1.0.8',
              'pluggy': '0.12.0',
              'py': '1.8.1',
              'py._vendored_packages.apipkg': '1.4',
              'py.test': '5.3.4',
              'pytest': '5.3.4',
              're': '2.2.1',
              'zlib': '1.0'}}
```

pcdsutils/tests/test_logging.py::test_log_exception_udp
```
 {'exc_text': 'Traceback (most recent call last):\n'
             '  File '
             '"/Users/klauer/docs/Repos/pcdsutils/pcdsutils/tests/test_logging.py", '
             'line 70, in test_log_exception_udp\n'
             '    testabcd  # noqa\n'
             "NameError: name 'testabcd' is not defined",
 'filename': 'test_logging.py',
 'lineno': 72,
 'msg': 'test2',
 'pathname': '/Users/klauer/docs/Repos/pcdsutils/pcdsutils/tests/test_logging.py',
 'schema': 'python-event-0',
 'source': 'test_logging.test_log_exception_udp:72',
 'versions': {'_csv': '1.0',
              '_decimal': '1.70',
              '_pytest': '5.3.4',
              'argparse': '1.1',
              'attr': '19.3.0',
              'coverage': '5.0.3',
              'coverage.jsonreport': '5.0.3',
              'coverage.sqldata': '5.0.3',
              'coverage.version': '5.0.3',
              'coverage.xmlreport': '5.0.3',
              'csv': '1.0',
              'decimal': '1.70',
              'importlib_metadata': '1.4.0',
              'json': '2.0.9',
              'logging': '0.5.1.2',
              'more_itertools': '8.1.0',
              'optparse': '1.5.3',
              'packaging': '20.0',
              'packaging.__about__': '20.0',
              'pcdsutils': '0.0.0+2.g2942a19.dirty',
              'platform': '1.0.8',
              'pluggy': '0.12.0',
              'py': '1.8.1',
              'py._vendored_packages.apipkg': '1.4',
              'py.test': '5.3.4',
              'pytest': '5.3.4',
              're': '2.2.1',
              'zlib': '1.0'}}
```
</details>

Closes #2 