### PR TITLE
REF: use portable platform.uname() to fix win32 support

### DIFF
--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -2,6 +2,7 @@ import copy
 import json
 import logging
 import os
+import platform
 import queue as queue_module
 import socket
 import sys
@@ -55,13 +56,7 @@ _LOGGER_KEY_RENAMES = {
     'threadName': 'thread_name',
 }
 
-_SYSTEM_UNAME_DICT = {
-    'sysname': os.uname().sysname,
-    'release': os.uname().release,
-    'version': os.uname().version,
-    'machine': os.uname().machine,
-}
-
+_SYSTEM_UNAME_DICT = dict(platform.uname()._asdict())
 _CURRENT_HANDLER = None
 
 


### PR DESCRIPTION
Closes #11 

Noted failing on conda-forge tests

Keys will change slightly, but that's not an issue for now. See: https://docs.python.org/3/library/platform.html#platform.uname