### PR TITLE
ENH: add release notes utility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+    -   id: no-commit-to-branch
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-ast
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: check-xml
+    -   id: check-yaml
+        exclude: '^(conda-recipe/meta.yaml)$'
+    -   id: debug-statements
+
+-   repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.8.3
+    hooks:
+    -   id: flake8
+
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.5.2
+    hooks:
+    -   id: isort

--- a/pcdsutils/release_notes.py
+++ b/pcdsutils/release_notes.py
@@ -1,0 +1,104 @@
+"""
+Release notes generation tool.
+
+Create RST-compatible release notes from GitHub releases.
+"""
+
+import argparse
+import re
+import sys
+from typing import Dict, List
+
+import pypandoc
+import requests
+
+ISSUE_RE = re.compile(r'#(\d+)')
+DESCRIPTION = __doc__
+
+
+def generate_releases(organization: str,
+                      repository: str,
+                      releases: List[dict],
+                      *, file=sys.stdout):
+    """
+    Generate the release notes.
+
+    Parameters
+    ----------
+    organization : str
+        The organization (e.g., pcdshub).
+
+    repository : str
+        The repository (e.g., lucid).
+
+    releases : list of dict
+        Releases from the GitHub API.
+
+    file : file-like object, optional
+        Where to write the release notes.
+    """
+    repo_url = f'https://github.com/{organization}/{repository}'
+    print('''\
+=================
+ Release History
+=================
+
+''', file=file)
+
+    for release in releases:
+        release['created_at'] = str(release['created_at'])[:10]
+        header = '{tag_name} ({created_at})'.format(**release)
+        print(header, file=file)
+        print('=' * len(header), file=file)
+        print(file=file)
+        body, _ = ISSUE_RE.subn(fr'[#\1]({repo_url}/issues/\1)',
+                                release['body'])
+        print(pypandoc.convert_text(body, to='rst', format='md',
+                                    extra_args=[]),
+              file=file)
+        print(file=file)
+
+
+def get_releases(organization: str, repository: str) -> List[Dict]:
+    """
+    Generate the release notes.
+
+    Parameters
+    ----------
+    organization : str
+        The organization (e.g., pcdshub).
+
+    repository : str
+        The repository (e.g., lucid).
+
+    Returns
+    -------
+    releases : list of dict
+        List of dictionaries with release information.
+    """
+    req = requests.get(
+        f'https://api.github.com/repos/{organization}/{repository}/releases'
+    )
+
+    if req.status_code != 200:
+        sys.exit(f'Request failed with error code: {req.status_code}')
+
+    return req.json()
+
+
+def create_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument('organization', type=str)
+    parser.add_argument('repository', type=str)
+    return parser
+
+
+def main():
+    parser = create_arg_parser()
+    args = parser.parse_args()
+    releases = get_releases(args.organization, args.repository)
+    generate_releases(args.organization, args.repository, releases)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes #14 

<!--- Provide a general summary of your changes in the Title above -->
## Description
Release notes utility converts from GitHub releases to `release_notes.rst` for documentation.

Requires pypandoc and requests, but I don't think we should add these to pcdsutils's requirements unless others do.
Also not adding this as a command-line entry for now. It can be invoked easily enough using `python -m pcdsutils.release_notes`

## Motivation and Context
* Made sense to do this before releasing ads-ioc

## How Has This Been Tested?
With one release notes generation