### PR TITLE
ENH: transplant ext_scripts from pcdsdaq

### DIFF
--- a/pcdsutils/ext_scripts.py
+++ b/pcdsutils/ext_scripts.py
@@ -1,0 +1,99 @@
+import logging
+import re
+import socket
+import subprocess
+
+
+logger = logging.getLogger(__name__)
+CNF = '/reg/g/pcds/dist/pds/{0}/scripts/{0}.cnf'
+SCRIPTS = '/reg/g/pcds/engineering_tools/{}/scripts/{}'
+TOOLS = '/reg/g/pcds/dist/pds/tools/{}/{}'
+
+
+def call_script(args, timeout=None, ignore_return_code=False):
+    logger.debug('Calling external script %s with timeout=%s,'
+                 ' ignore_fail=%s', args, timeout, ignore_return_code)
+    try:
+        return subprocess.check_output(args, universal_newlines=True,
+                                       timeout=timeout)
+    except subprocess.CalledProcessError as exc:
+        if ignore_return_code:
+            return exc.output
+        else:
+            logger.debug('CalledProcessError from %s', args, exc_info=True)
+            raise
+    except Exception:
+        logger.debug('Exception raised from %s', args, exc_info=True)
+        raise
+
+
+cache = {}
+
+
+def cache_script(args, timeout=None, ignore_return_code=False):
+    key = ' '.join(args)
+    try:
+        return cache[key]
+    except KeyError:
+        output = call_script(args, timeout=timeout,
+                             ignore_return_code=ignore_return_code)
+        cache[key] = output
+        return output
+
+
+def clear_script_cache():
+    global cache
+    cache = {}
+
+
+def get_hutch_name(timeout=10):
+    script = SCRIPTS.format('latest', 'get_hutch_name')
+    name = cache_script(script, timeout=timeout)
+    return name.lower().strip(' \n')
+
+
+# API Backwards compatibility
+hutch_name = get_hutch_name
+
+
+def get_run_number(hutch=None, live=False, timeout=1):
+    latest = hutch or 'latest'
+    script = SCRIPTS.format(latest, 'get_lastRun')
+    args = [script]
+    if hutch is not None:
+        args += ['-i', hutch]
+    if live:
+        args += ['-l']
+    run_number = call_script(args, timeout=timeout)
+    return int(run_number)
+
+
+def get_ami_proxy(hutch, timeout=10):
+    """
+    Match the output text from procmgr ami status.
+
+    The line we're looking for always includes the text ami_proxy.
+    The -I argument holds the IP address or hostname of the ami proxy.
+
+    I thought the first host in the list was the name of the ami proxy, but
+    this does not seem to be consistent with what the old hutch python is
+    doing, so I will continue to searching for -I here.
+    """
+    domain_re = re.compile('.pcdsn$')
+    proxy_re = re.compile(r'ami_proxy.+-I\s+(?P<proxy>\S+)\s')
+    ip_re = re.compile(r'\d+\.\d+\.\d+\.\d+')
+    hutch = hutch.lower()
+    cnf = CNF.format(hutch)
+    procmgr = TOOLS.format('procmgr', 'procmgr')
+    output = cache_script([procmgr, 'status', cnf, 'ami_proxy'],
+                          timeout=timeout,
+                          ignore_return_code=True)
+    for line in output.split('\n'):
+        proxy_match = proxy_re.search(line)
+        if proxy_match:
+            ami_proxy = proxy_match.group('proxy')
+            ip_match = ip_re.match(ami_proxy)
+            if ip_match:
+                domain_name, _, _ = socket.gethostbyaddr(ami_proxy)
+                ami_proxy = domain_re.sub('', domain_name)
+            return ami_proxy

--- a/pcdsutils/tests/test_ext_scripts.py
+++ b/pcdsutils/tests/test_ext_scripts.py
@@ -20,7 +20,7 @@ def test_call_script():
     assert isinstance(ext.call_script(bad_args, ignore_return_code=True), str)
 
 
-def test_hutch_name(nosim, monkeypatch):
+def test_hutch_name(monkeypatch):
     logger.debug('test_hutch_name')
 
     def fake_hutch_name(*args, **kwargs):
@@ -30,7 +30,7 @@ def test_hutch_name(nosim, monkeypatch):
     assert ext.get_hutch_name() == 'tst'
 
 
-def test_run_number(nosim, monkeypatch):
+def test_run_number(monkeypatch):
     logger.debug('test_run_number')
 
     def fake_run_number(*args, **kwargs):

--- a/pcdsutils/tests/test_ext_scripts.py
+++ b/pcdsutils/tests/test_ext_scripts.py
@@ -1,0 +1,69 @@
+import logging
+
+import pytest
+import socket
+import subprocess
+
+import pcdsutils.ext_scripts as ext
+
+logger = logging.getLogger(__name__)
+
+
+def test_call_script():
+    logger.debug('test_call_script')
+    assert isinstance(ext.call_script('uname'), str)
+    with pytest.raises(FileNotFoundError):
+        ext.call_script('definitelynotarealscriptgeezman')
+    bad_args = ['uname', '-notanoption']
+    with pytest.raises(subprocess.CalledProcessError):
+        ext.call_script(bad_args)
+    assert isinstance(ext.call_script(bad_args, ignore_return_code=True), str)
+
+
+def test_hutch_name(nosim, monkeypatch):
+    logger.debug('test_hutch_name')
+
+    def fake_hutch_name(*args, **kwargs):
+        return 'tst\n'
+
+    monkeypatch.setattr(ext, 'call_script', fake_hutch_name)
+    assert ext.get_hutch_name() == 'tst'
+
+
+def test_run_number(nosim, monkeypatch):
+    logger.debug('test_run_number')
+
+    def fake_run_number(*args, **kwargs):
+        return '1\n'
+
+    monkeypatch.setattr(ext, 'call_script', fake_run_number)
+    assert ext.get_run_number(hutch='tst', live=True) == 1
+
+
+def test_get_ami_proxy(monkeypatch):
+    logger.debug('test_get_ami_proxy')
+
+    def fake_procmgr(*args, **kwargs):
+        return ("/reg/g/pcds/dist/pds/tools/procmgr/procmgr: using config "
+                "file '/reg/g/pcds/dist/pds/xpp/scripts/p1.cnf.last'\n"
+                "Running, started on host xpp-daq by user xppopr.\n"
+                "Warning! If current host xpp-control is not on the same "
+                "subnets as start host xpp-daq, status could be incorrect.\n"
+                "Host          UniqueID     Status     PID    PORT   "
+                "Command+Args\n"
+                "172.21.22.64  ami_proxy    RUNNING    7145   29118  "
+                "/reg/g/pcds/dist/pds/ami-8.8.14-p8.9.0/build/ami/bin/"
+                "x86_64-rhel7-opt/ami_proxy -I 172.21.38.64 -i 172.21.22.64 "
+                "-s 239.255.35.1\n")
+
+    def fake_gethostbyaddr(ip):
+        logger.debug(ip)
+        if ip == '172.21.38.64':
+            return ('tst-amiproxy.pcdsn', None, None)
+        else:
+            return ('regex_fail', None, None)
+
+    monkeypatch.setattr(ext, 'call_script', fake_procmgr)
+    monkeypatch.setattr(socket, 'gethostbyaddr', fake_gethostbyaddr)
+
+    assert ext.get_ami_proxy('tst') == 'tst-amiproxy'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Move `pcdsdaq.ext_scripts` to `pcdsutils.ext_scripts` with no changes.
There is probably some cleanup to do here. I think we should do it in a follow-up PR to keep the change history clear.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In general, python wrappers for `engineering_tools`, `pds/tools` , and other shell scripts should be importable without importing pcdsdaq.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A, but the code did not reference anything in `pcdsdaq` so I expect it to work the same.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I haven't done this yet.

<!--
## Screenshots (if appropriate):
-->
