### PR TITLE
MNT: ext_scripts cleanup

### DIFF
--- a/pcdsutils/ext_scripts.py
+++ b/pcdsutils/ext_scripts.py
@@ -75,6 +75,8 @@ def get_hutch_name(timeout=10):
     The current hutch is defined by which server we call
     this function from.
 
+    This function caches the output.
+
     Parameters
     ----------
     timeout : int or float, optional
@@ -129,6 +131,8 @@ def get_run_number(hutch=None, live=False, timeout=1):
 def get_ami_proxy(hutch, timeout=10):
     """
     Call procmgr to determine the lcls-I ami proxy hostname.
+
+    This function caches the output.
 
     This works using a regex on the output text from procmgr ami status.
 

--- a/pcdsutils/ext_scripts.py
+++ b/pcdsutils/ext_scripts.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import re
 import socket
@@ -49,31 +50,15 @@ def call_script(args, timeout=None, ignore_return_code=False):
         raise
 
 
-cache = {}
-
-
-def cache_script(args, timeout=None, ignore_return_code=False):
-    key = ' '.join(args)
-    try:
-        return cache[key]
-    except KeyError:
-        output = call_script(args, timeout=timeout,
-                             ignore_return_code=ignore_return_code)
-        cache[key] = output
-        return output
-
-
-def clear_script_cache():
-    global cache
-    cache = {}
-
-
+@functools.lru_cache(maxsize=None)
 def get_hutch_name(timeout=10):
     """
     Call get_hutch_name to return the name of the current hutch.
 
     The current hutch is defined by which server we call
     this function from.
+
+    This function's output is cached.
 
     Parameters
     ----------
@@ -86,7 +71,7 @@ def get_hutch_name(timeout=10):
     hutch_name : str
     """
     script = SCRIPTS.format('latest', 'get_hutch_name')
-    name = cache_script(script, timeout=timeout)
+    name = call_script(script, timeout=timeout)
     return name.lower().strip(' \n')
 
 
@@ -126,9 +111,12 @@ def get_run_number(hutch=None, live=False, timeout=1):
     return int(run_number)
 
 
+@functools.lru_cache(maxsize=None)
 def get_ami_proxy(hutch, timeout=10):
     """
     Call procmgr to determine the lcls-I ami proxy hostname.
+
+    This function's output is cached.
 
     This works using a regex on the output text from procmgr ami status.
 
@@ -159,9 +147,9 @@ def get_ami_proxy(hutch, timeout=10):
     hutch = hutch.lower()
     cnf = CNF.format(hutch)
     procmgr = TOOLS.format('procmgr', 'procmgr')
-    output = cache_script([procmgr, 'status', cnf, 'ami_proxy'],
-                          timeout=timeout,
-                          ignore_return_code=True)
+    output = call_script([procmgr, 'status', cnf, 'ami_proxy'],
+                         timeout=timeout,
+                         ignore_return_code=True)
     for line in output.split('\n'):
         proxy_match = proxy_re.search(line)
         if proxy_match:

--- a/pcdsutils/ext_scripts.py
+++ b/pcdsutils/ext_scripts.py
@@ -11,6 +11,28 @@ TOOLS = '/reg/g/pcds/dist/pds/tools/{}/{}'
 
 
 def call_script(args, timeout=None, ignore_return_code=False):
+    """
+    Helper script for external script error handling and logging.
+
+    Parameters
+    ----------
+    args : list of str
+        The script name and arguments. See subprocess.check_output.
+
+    timeout : int or float, optional
+        The time to wait before marking the script call as failed.
+        If omitted, we wait forever.
+
+    ignore_return_code : bool, optional
+        Defaults to False. If True, we'll ignore the return code and
+        return the output anyway, even though the script failed.
+
+    Returns
+    -------
+    output : str
+        String output from the script call. This is a single string with
+        lines separated by newline characters.
+    """
     logger.debug('Calling external script %s with timeout=%s,'
                  ' ignore_fail=%s', args, timeout, ignore_return_code)
     try:
@@ -47,6 +69,22 @@ def clear_script_cache():
 
 
 def get_hutch_name(timeout=10):
+    """
+    Call get_hutch_name to return the name of the current hutch.
+
+    The current hutch is defined by which server we call
+    this function from.
+
+    Parameters
+    ----------
+    timeout : int or float, optional
+        Time to wait for get_hutch_name to finish.
+        Defaults to a 10 second timeout.
+
+    Returns
+    -------
+    hutch_name : str
+    """
     script = SCRIPTS.format('latest', 'get_hutch_name')
     name = cache_script(script, timeout=timeout)
     return name.lower().strip(' \n')
@@ -57,6 +95,26 @@ hutch_name = get_hutch_name
 
 
 def get_run_number(hutch=None, live=False, timeout=1):
+    """
+    Call get_lastRun to return the run number of the last daq run.
+
+    Parameters
+    ----------
+    hutch : str, optional
+        The name of the hutch to get the run number for. If omitted, the hutch
+        name will be determined automatically via cli argument.
+
+    live : bool, optional
+        Defaults to False. If True, we'll return the number of the current run.
+
+    timeout : int or float, optional
+        Time to wait for get_lastRun to finish.
+        Defaults to a 1 second timeout.
+
+    Returns
+    -------
+    run_number : int
+    """
     latest = hutch or 'latest'
     script = SCRIPTS.format(latest, 'get_lastRun')
     args = [script]
@@ -70,7 +128,9 @@ def get_run_number(hutch=None, live=False, timeout=1):
 
 def get_ami_proxy(hutch, timeout=10):
     """
-    Match the output text from procmgr ami status.
+    Call procmgr to determine the lcls-I ami proxy hostname.
+
+    This works using a regex on the output text from procmgr ami status.
 
     The line we're looking for always includes the text ami_proxy.
     The -I argument holds the IP address or hostname of the ami proxy.
@@ -78,6 +138,20 @@ def get_ami_proxy(hutch, timeout=10):
     I thought the first host in the list was the name of the ami proxy, but
     this does not seem to be consistent with what the old hutch python is
     doing, so I will continue to searching for -I here.
+
+    Parameters
+    ----------
+    hutch : str
+        Name of the hutch to use.
+
+    timeout : int or float
+        Time to wait for a response from procmgr.
+        Defaults to a 10 second timeout.
+
+    Returns
+    -------
+    ami_proxy : str
+        The hostname of the server used as a proxy for ami data.
     """
     domain_re = re.compile('.pcdsn$')
     proxy_re = re.compile(r'ami_proxy.+-I\s+(?P<proxy>\S+)\s')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Follow-up to #22 where we clean up the module a bit by adding docstrings ~~and switching to the built-in `functools.lru_cache`~~

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The code is easier to follow now with the relevant docstrings.
- ~~Using built-ins is always preferred when they exist~~ it will require some refactoring to switch to using the built-in caching

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively + the tests still pass

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings

<!--
## Screenshots (if appropriate):
-->
