### PR TITLE
FIX: version difference display broken

### DIFF
--- a/pcdsutils/requirements.py
+++ b/pcdsutils/requirements.py
@@ -2,8 +2,8 @@ import argparse
 import logging
 import pathlib
 import re
-import yaml
 
+import yaml
 
 logger = logging.getLogger(__name__)
 
@@ -169,7 +169,7 @@ def compare_requirements(conda_deps, pip_deps):
     missing_in_pip = set(conda_deps_name) - set(pip_deps_name)
     missing_in_conda = set(pip_deps_name) - set(conda_deps_name)
     version_mismatch = [
-        dict(conda=conda_deps_name[dep], pip=pip_deps_name[dep])
+        f"conda: {conda_deps_name[dep]} pip: {pip_deps_name[dep]}"
         for dep in conda_deps_name
         if dep not in missing_in_pip
         and conda_deps_name[dep] != pip_deps_name[dep]


### PR DESCRIPTION
Was:

```
Version mismatch:
TypeError: '<' not supported between instances of 'dict' and 'dict'
```

Is now:

```
:pcdsdevices klauer$ requirements-compare .
--- requirements.txt: host/build/run ---
Missing in pip:
- matplotlib-base
- numpy

Version mismatch:
- conda: bluesky>=1.6.4 pip: bluesky>=1.2.0
- conda: ophyd>=1.5.1 pip: ophyd>=1.2.0
- conda: pcdscalc>=0.2.0 pip: pcdscalc
- conda: pcdsutils>=0.4.0 pip: pcdsutils
- conda: pyepics>=3.4.2 pip: pyepics
- conda: pytmc>=2.7.0 pip: pytmc
```