### PR TITLE
ENH: add log_exception and related tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -18,11 +18,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.9.0
+    rev: 3.9.2
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.7.0
+    rev: 5.9.2
     hooks:
     -   id: isort

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -9,6 +9,8 @@ import queue as queue_module
 import socket
 import sys
 
+from .utils import get_fully_qualified_domain_name
+
 # The special logger:
 logger = logging.getLogger('pcds-logging')
 
@@ -21,6 +23,9 @@ NO_LOG_EXCEPTIONS = (KeyboardInterrupt, SystemExit)
 DEFAULT_LOG_HOST = os.environ.get('PCDS_LOG_HOST', 'ctl-logsrv01.pcdsn')
 DEFAULT_LOG_PORT = int(os.environ.get('PCDS_LOG_PORT', 54320))
 DEFAULT_LOG_PROTO = os.environ.get('PCDS_LOG_PROTO', 'tcp')
+ALLOWED_LOG_DOMAINS = set(
+    os.environ.get("PCDS_LOG_DOMAINS", ".pcdsn .slac.stanford.edu").split(" ")
+)
 
 _LOGGER_SCHEMA_VERSION = 0
 
@@ -310,3 +315,9 @@ def log_exception(
         kwargs = dict(stacklevel=stacklevel + 1)
 
     logger.log(level, message, exc_info=exc_info, **kwargs)
+
+
+def centralized_logging_enabled() -> bool:
+    """Returns True if centralized logging should be enabled."""
+    fqdn = get_fully_qualified_domain_name()
+    return any(fqdn.endswith(domain) for domain in ALLOWED_LOG_DOMAINS)

--- a/pcdsutils/utils.py
+++ b/pcdsutils/utils.py
@@ -1,7 +1,9 @@
-import sys
+import functools
 import importlib
 import inspect
 import logging
+import socket
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -75,3 +77,17 @@ def get_instance_by_name(klass, *args, **kwargs):
         logger.exception('Failed to instantiate object for class %s '
                          'using %s and %s', klass, args, kwargs)
         raise
+
+
+@functools.lru_cache(maxsize=1)
+def get_fully_qualified_domain_name():
+    """Get the fully qualified domain name of this host."""
+    try:
+        return socket.getfqdn()
+    except Exception:
+        logger.warning(
+            "Unable to get machine name.  Things like centralized "
+            "logging may not work."
+        )
+        logger.debug("getfqdn failed", exc_info=True)
+        return ""


### PR DESCRIPTION
With `log_exception_to_central_server` now in hutch-python and lucid, it only made sense to bring it upstream to pcdsutils where the central logger lives.

The previous naming was a bit superfluous since now it belongs in the centralized-logging helper module, so I chose to just name it `log_exception`. Open to changing it, if you guys feel otherwise.

Contains the recent `stacklevel` option, of course, as well.