### PR TITLE
ENH: Add callback exception deduplication filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,8 @@ ENV/
 # vim swap files
 *.swp
 
-# None of the logs 
+# None of the logs
 /logs/*
+
+# vscode
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ import:
   #   - Documentation using doctr
   #   - Conda Package - uploaded to pcds-dev and pcds-tag
   #   - PyPI
-  - pcdshub/pcds-ci-helpers:travis/shared_configs/standard-python-conda-latest.yml
+  - pcdshub/pcds-ci-helpers:travis/shared_configs/standard-python-conda.yml

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,10 +13,10 @@ build:
 
 requirements:
     build:
-      - python >=3.6
+      - python >=3.7
       - setuptools
     run:
-      - python >=3.6
+      - python >=3.7
       - pypandoc
       - pyyaml
       - qtpyinheritance

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@
 # the documentation) but not necessarily required for _using_ it.
 coverage
 flake8
+ophyd
 pytest>=6.2.0
 sphinx
 # These are dependencies of various sphinx extensions for documentation.

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -627,7 +627,7 @@ class OphydObjectRecordInfo:
     """
     message: str
     pathname: str
-    exc_info: typing.Optional[tuple]
+    exception: Exception
     object_name: str
 
     @classmethod
@@ -640,9 +640,9 @@ class OphydObjectRecordInfo:
         """
         try:
             return cls(
-                message=record.getMessage(),
+                message=record.msg,
                 pathname=record.pathname,
-                exc_info=record.exc_info,
+                exception=record.exc_info[0],
                 object_name=record.ophyd_object_name,
             )
         except AttributeError as exc:

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -683,9 +683,9 @@ class OphydCallbackExceptionDemoter(logging.Filter):
     levelno: int
     levelname: str
     only_duplicates: bool
-    _logger: typing.Optional[logging.Logger]
+    cache: set[OphydObjectRecordInfo]
     counter: int
-    info: set[OphydObjectRecordInfo]
+    _logger: typing.Optional[logging.Logger]
 
     def __init__(
         self,
@@ -695,9 +695,9 @@ class OphydCallbackExceptionDemoter(logging.Filter):
         self.levelno = validate_log_level(level)
         self.levelname = logging.getLevelName(self.levelno)
         self.only_duplicates = only_duplicates
-        self._logger = None
+        self.cache = set()
         self.counter = 0
-        self.info = set()
+        self._logger = None
 
     @classmethod
     def install(

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -499,6 +499,7 @@ class DemotionFilter(logging.Filter):
     Child classes should override the following attributes:
     - record_dataclass (inherit and customize from RecordInfo)
     - default_logger (logging.Logger instance)
+    - cache (just the type annotation)
 
     Parameters
     ----------

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -461,11 +461,184 @@ def uninstall_log_warning_handler() -> None:
 
 
 @dataclasses.dataclass(eq=True, frozen=True)
-class WarningRecordInfo:
+class RecordInfo:
+    """
+    Parent dataclass to define the interface for DemotionFilter
+    """
+    message: str
+
+    @classmethod
+    def from_record(cls, record: logging.LogRecord) -> RecordInfo:
+        """
+        Create a OphydObjectRecordInfo from a LogRecord.
+        """
+        try:
+            return cls(
+                message=record.msg,
+            )
+        except AttributeError as exc:
+            raise ValueError(
+                'Received invalid record'
+            ) from exc
+
+
+class DemotionFilter(logging.Filter):
+    """
+    Filter parent class for demoting log records.
+
+    Supports:
+    - Demoting duplicate records when paired with a hashable dataclass
+    - Optionally demoting all records that match a specification
+    - A counter that tracks how many records have been demoted
+
+    Child classes can/should override the following methods:
+    - should_demote (without super)
+    - __init__ (optional, and with super)
+
+
+    Child classes should override the following attributes:
+    - record_dataclass (inherit and customize from RecordInfo)
+    - default_logger (logging.Logger instance)
+
+    Parameters
+    ----------
+    level: str or int, optional
+        The level to demote matching messages to. Defaults to logging.DEBUG,
+        but this behavior can be overridden in the child class.
+    only_duplicates: bool, optional
+        If True, the default, only demote duplicated log messages.
+        If False, demote all log messages that pass through should_demote.
+        This must be False if no record_dataclass is provided.
+    """
+    record_dataclass: type = RecordInfo
+    default_logger: typing.Optional[logging.Logger] = None
+
+    levelno: int
+    levelname: str
+    only_duplicates: bool
+    cache: set[RecordInfo]
+    counter: int
+    _logger: typing.Optional[logging.Logger]
+
+    def __init__(
+        self,
+        level: typing.Union[str, int] = logging.DEBUG,
+        only_duplicates: bool = True,
+    ):
+        self.levelno = validate_log_level(level)
+        self.levelname = logging.getLevelName(self.levelno)
+        self.only_duplicates = only_duplicates
+        self.cache = set()
+        self.counter = 0
+        self._logger = None
+
+    @classmethod
+    def install(
+        cls,
+        level: typing.Union[str, int] = logging.DEBUG,
+        only_duplicates: bool = True,
+        logger: typing.Optional[logging.Logger] = None,
+    ) -> DemotionFilter:
+        """
+        Create and apply the DemotionFilter to a specific logger,
+        or the default logger.
+
+        Parameters
+        ----------
+        level : str or int, optional
+            The log level or name of the log level to reduce
+            log messages to. Defaults to logging.DEBUG.
+        only_duplicates: bool, optional
+            If True, the default, only apply this to duplicated log messages.
+            If False, apply it to all log messages.
+        logger : logging.Logger, optional
+            The logger to apply the filter to, or the default logger.
+
+        Returns
+        -------
+        filt : DemotionFilter
+            The filter object that we've applied to the logger. Useful for
+            debugging.
+        """
+        filt = cls(
+            level=level,
+            only_duplicates=only_duplicates,
+        )
+        filt.install_self(logger=logger or cls.default_logger)
+        return filt
+
+    def install_self(
+        self,
+        logger: typing.Optional[logging.Logger] = None,
+    ) -> None:
+        """
+        Convenience method for adding this filter to a logger.
+
+        Parameters
+        ----------
+        logger : logging.Logger, optional
+            The logger to apply the filter to. Defaults to the class-defined
+            default_logger.
+        """
+        logger = logger or self.default_logger
+        logger.addFilter(self)
+        self._logger = logger
+
+    def uninstall(self):
+        """
+        Convenience method for removing this filter.
+
+        Requires the filter to have been originally created and applied using
+        the "install" class method or the "install_self" method.
+
+        Intended to help with the unit testing.
+        """
+        self._logger.removeFilter(self)
+
+    def filter(self, record: logging.LogRecord) -> typing.Literal[True]:
+        """
+        Demote the log message if appropriate, return True to let it pass.
+        """
+        try:
+            info = self.record_dataclass.from_record(record)
+        except ValueError:
+            return True
+        if self.should_demote(record, info) and record.levelno > self.levelno:
+            if info in self.cache or not self.only_duplicates:
+                record.levelno = self.levelno
+                record.levelname = self.levelname
+                self.counter += 1
+            else:
+                self.cache.add(info)
+        return True
+
+    def reset_counter(self):
+        self.counter = 0
+
+    def should_demote(
+        self,
+        record: logging.LogRecord,
+        info: RecordInfo
+    ) -> bool:
+        """
+        Return True if we should demote the record, False otherwise.
+
+        Parameters
+        ----------
+        record: logging.LogRecord
+            The record instance passed into the filter.
+        info: RecordInfo
+            The record info dataclass, which may be more convenient
+            for implementing this method.
+        """
+        raise NotImplementedError("Implement me in child class")
+
+
+@dataclasses.dataclass(eq=True, frozen=True)
+class WarningRecordInfo(RecordInfo):
     """
     Hashable collection of the unique information from a warnings.warn call.
     """
-    message: str
     category: type[Warning]
     filename: str
     lineno: int
@@ -492,7 +665,7 @@ class WarningRecordInfo:
             ) from exc
 
 
-class LogWarningLevelFilter(logging.Filter):
+class LogWarningLevelFilter(DemotionFilter):
     """
     Filter to decrease the log level of repeat warnings.
 
@@ -510,94 +683,29 @@ class LogWarningLevelFilter(logging.Filter):
     adjust the level of the repeat messages to avoid cluttering the user's
     view, or to remove them entirely.
 
+    This filter incorporates a resettable counter that will count the number
+    of demoted log messages.
+
     Parameters
     ----------
     level : str or int, optional
         The log level or name of the log level to reduce dupliacte
         log messages to. Defaults to logging.DEBUG.
+    only_duplicates: bool, optional
+        If True, the default, only demote duplicated log messages.
+        If False, demote all log messages that pass through should_demote.
+        This must be False if no record_dataclass is provided.
     """
-    levelno: int
-    levelname: str
+    record_dataclass: type = WarningRecordInfo
+    default_logger: typing.Optional[logging.Logger] = warnings_logger
+
     cache: set[WarningRecordInfo]
-    _logger: typing.Optional[logging.Logger]
 
-    def __init__(
-        self,
-        level: typing.Union[str, int] = logging.DEBUG,
-    ):
-        self.levelno = validate_log_level(level)
-        self.levelname = logging.getLevelName(self.levelno)
-        self.cache = set()
-        self._logger = None
-
-    def filter(self, record: logging.LogRecord) -> typing.Literal[True]:
+    def should_demote(self, *args, **kwargs) -> typing.Literal[True]:
         """
-        Adjust the level of the warnings log message if we've seen it before.
-
-        Always returns "True" to let the log pass through.
+        All warnings should be demoted (only_duplicates=True)
         """
-        try:
-            info = WarningRecordInfo.from_record(record)
-        except ValueError:
-            # Must not be a warnings log record, skip
-            return True
-        if info in self.cache:
-            record.levelno = self.levelno
-            record.levelname = self.levelname
-        else:
-            self.cache.add(info)
         return True
-
-    @classmethod
-    def install(
-        cls,
-        level: typing.Union[str, int] = logging.DEBUG,
-        logger: logging.Logger = warnings_logger,
-    ) -> LogWarningLevelFilter:
-        """
-        Apply the LogWarningLevelFilter to the warnings logger.
-
-        Parameters
-        ----------
-        level : str or int, optional
-            The log level or name of the log level to reduce dupliacte
-            log messages to. Defaults to logging.DEBUG.
-        logger : logging.Logger, optional
-            The logger to apply the filter to. Defaults to the warnings_logger.
-
-        Returns
-        -------
-        filt : LogWarningLevelFilter
-            The filter object that we've applied to the logger. Useful for
-            debugging.
-        """
-        filt = cls(level=level)
-        filt.install_self(logger=logger)
-        return filt
-
-    def install_self(self, logger: logging.Logger = warnings_logger) -> None:
-        """
-        Convenience method for adding this filter to a logger.
-
-        Parameters
-        ----------
-        logger : logging.Logger, optional
-            The logger to apply the filter to. Defaults to the warnings_logger.
-        """
-        logger.addFilter(self)
-        self._logger = logger
-
-    def uninstall(self) -> None:
-        """
-        Convenience method for removing this filter.
-
-        Requires the filter to have been originally created and applied using
-        the "install" class method or the "install_self" method.
-
-        Intended to help with the unit testing.
-        """
-        if self._logger is not None:
-            self._logger.removeFilter(self)
 
 
 def standard_warnings_config() -> LogWarningLevelFilter:
@@ -621,13 +729,12 @@ objects_logger = logging.getLogger('ophyd.objects')
 
 
 @dataclasses.dataclass(eq=True, frozen=True)
-class OphydObjectRecordInfo:
+class OphydObjectRecordInfo(RecordInfo):
     """
     Hashable collection of the unique information from an ophyd.objects log
     """
-    message: str
     pathname: str
-    exception: Exception
+    exception: typing.Optional[Exception]
     object_name: str
 
     @classmethod
@@ -639,10 +746,14 @@ class OphydObjectRecordInfo:
         messages inside a log filter.
         """
         try:
+            if record.exc_info is None:
+                exception = None
+            else:
+                exception = record.exc_info[0]
             return cls(
                 message=record.msg,
                 pathname=record.pathname,
-                exception=record.exc_info[0],
+                exception=exception,
                 object_name=record.ophyd_object_name,
             )
         except AttributeError as exc:
@@ -652,7 +763,7 @@ class OphydObjectRecordInfo:
             ) from exc
 
 
-class OphydCallbackExceptionDemoter(logging.Filter):
+class OphydCallbackExceptionDemoter(DemotionFilter):
     """
     Filter that demotes the logging level of callback exceptions.
 
@@ -673,107 +784,32 @@ class OphydCallbackExceptionDemoter(logging.Filter):
     level : str or int, optional
         The log level or name of the log level to reduce dupliacte
         log messages to. Defaults to logging.DEBUG.
-    logger: logging.Logger, optional
-        The logger to apply the filter to. Defaults to the ophyd.objects
-        logger.
     only_duplicates: bool, optional
         If True, the default, only apply this to duplicated log messages.
         If False, apply it to all log messages.
     """
-    levelno: int
-    levelname: str
-    only_duplicates: bool
+    record_dataclass: type = OphydObjectRecordInfo
+    default_logger: typing.Optional[logging.Logger] = objects_logger
+
     cache: set[OphydObjectRecordInfo]
-    counter: int
-    _logger: typing.Optional[logging.Logger]
 
-    def __init__(
+    def should_demote(
         self,
-        level: typing.Union[str, int] = logging.DEBUG,
-        only_duplicates: bool = True,
-    ):
-        self.levelno = validate_log_level(level)
-        self.levelname = logging.getLevelName(self.levelno)
-        self.only_duplicates = only_duplicates
-        self.cache = set()
-        self.counter = 0
-        self._logger = None
-
-    @classmethod
-    def install(
-        cls,
-        level: typing.Union[str, int] = logging.DEBUG,
-        only_duplicates: bool = True,
-        logger: logging.Logger = objects_logger,
-    ) -> OphydCallbackExceptionDemoter:
+        record: logging.LogRecord,
+        info: RecordInfo
+    ) -> bool:
         """
-        Apply the OphydCallbackExceptionDemoter to the objects logger.
+        Return True if we should demote the record, False otherwise.
+
+        We'll match the log message template against the one
+        used for the callback exception messages.
 
         Parameters
         ----------
-        level : str or int, optional
-            The log level or name of the log level to reduce dupliacte
-            log messages to. Defaults to logging.DEBUG.
-        only_duplicates: bool, optional
-            If True, the default, only apply this to duplicated log messages.
-            If False, apply it to all log messages.
-        logger : logging.Logger, optional
-            The logger to apply the filter to. Defaults to the ophyd.objects
-            logger.
-
-        Returns
-        -------
-        filt : OphydCallbackExceptionDemoter
-            The filter object that we've applied to the logger. Useful for
-            debugging.
+        record: logging.LogRecord
+            The record instance passed into the filter.
+        info: RecordInfo
+            The record info dataclass, which may be more convenient
+            for implementing this method.
         """
-        filt = cls(
-            level=level,
-            only_duplicates=only_duplicates,
-        )
-        filt.install_self(logger=logger)
-        return filt
-
-    def install_self(self, logger: logging.Logger = objects_logger) -> None:
-        """
-        Convenience method for adding this filter to a logger.
-
-        Parameters
-        ----------
-        logger : logging.Logger, optional
-            The logger to apply the filter to. Defaults to the ophyd.objects
-            logger.
-        """
-        logger.addFilter(self)
-        self._logger = logger
-
-    def uninstall(self):
-        """
-        Convenience method for removing this filter.
-
-        Requires the filter to have been originally created and applied using
-        the "install" class method or the "install_self" method.
-
-        Intended to help with the unit testing.
-        """
-        self._logger.removeFilter(self)
-
-    def filter(self, record: logging.LogRecord) -> typing.Literal[True]:
-        """
-        Demote the log message if appropriate, return True to let it pass.
-        """
-        if 'Subscription %s callback exception' in record.msg:
-            try:
-                info = OphydObjectRecordInfo.from_record(record)
-            except ValueError:
-                return True
-            if not self.only_duplicates or info in self.cache:
-                record.levelno = self.levelno
-                record.levelname = self.levelname
-                self.counter += 1
-            else:
-                self.cache.add(info)
-        return True
-
-    def reset_counter(self):
-        self.counter = 0
+        return 'Subscription %s callback exception' in info.message

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -565,7 +565,7 @@ class DemotionFilter(logging.Filter):
             level=level,
             only_duplicates=only_duplicates,
         )
-        filt.install_self(logger=logger or cls.default_logger)
+        filt.install_self(logger=logger)
         return filt
 
     def install_self(

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -690,7 +690,7 @@ class LogWarningLevelFilter(DemotionFilter):
     Parameters
     ----------
     level : str or int, optional
-        The log level or name of the log level to reduce dupliacte
+        The log level or name of the log level to reduce duplicate
         log messages to. Defaults to logging.DEBUG.
     only_duplicates: bool, optional
         If True, the default, only demote duplicated log messages.
@@ -783,7 +783,7 @@ class OphydCallbackExceptionDemoter(DemotionFilter):
     Parameters
     ----------
     level : str or int, optional
-        The log level or name of the log level to reduce dupliacte
+        The log level or name of the log level to reduce duplicate
         log messages to. Defaults to logging.DEBUG.
     only_duplicates: bool, optional
         If True, the default, only apply this to duplicated log messages.

--- a/pcdsutils/tests/test_ext_scripts.py
+++ b/pcdsutils/tests/test_ext_scripts.py
@@ -1,14 +1,16 @@
 import logging
-
-import pytest
 import socket
 import subprocess
+import sys
+
+import pytest
 
 import pcdsutils.ext_scripts as ext
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='Fails on Windows.')
 def test_call_script():
     logger.debug('test_call_script')
     assert isinstance(ext.call_script('uname'), str)

--- a/pcdsutils/tests/test_logging.py
+++ b/pcdsutils/tests/test_logging.py
@@ -111,18 +111,30 @@ def test_warning_redirects(
     for cnt in range(10):
         caplog.clear()
         warnings.warn(message)
-        assert normal_warning_count == 0, f"Saw a normal warning! {cnt=}"
-        assert caplog.records, f"Did not find log records! {cnt=}"
-        assert len(caplog.records) == 1, f"Expected only 1 record! {cnt=}"
-        assert message in caplog.records[0].message, f"Wrong record! {cnt=}"
+        assert normal_warning_count == 0, (
+            f"Saw a normal warning! cnt={cnt}"
+        )
+        assert caplog.records, (
+            f"Did not find log records! cnt={cnt}"
+        )
+        assert len(caplog.records) == 1, (
+            f"Expected only 1 record! cnt={cnt}"
+        )
+        assert message in caplog.records[0].message, (
+            f"Wrong record! cnt={cnt}"
+        )
 
     pcdsutils.log.uninstall_log_warning_handler()
 
     for cnt in range(10):
         caplog.clear()
         warnings.warn(message)
-        assert not caplog.records, f"Has log records after uninstall! {cnt=}"
-        assert normal_warning_count == cnt + 1, f"No normal warning! {cnt=}"
+        assert not caplog.records, (
+            f"Has log records after uninstall! cnt={cnt}"
+        )
+        assert normal_warning_count == cnt + 1, (
+            f"No normal warning! cnt={cnt}"
+        )
 
 
 def test_warning_filter(
@@ -140,8 +152,12 @@ def test_warning_filter(
             for cnt in range(10):
                 caplog.clear()
                 warnings.warn(message)
-                assert caplog.records, f"Did not find log records! {cnt=}"
-                assert len(caplog.records) == 1, f"Too many records! {cnt=}"
+                assert caplog.records, (
+                    f"Did not find log records! cnt={cnt}"
+                )
+                assert len(caplog.records) == 1, (
+                    f"Too many records! cnt={cnt}"
+                )
                 record = caplog.records[0]
                 if not filtered or cnt == 0:
                     assert record.levelno == logging.WARNING
@@ -182,13 +198,21 @@ def test_exception_filter(
             target_records = [
                 rec for rec in caplog.records if rec.name == 'ophyd.objects'
             ]
-            assert target_records, f"Did not find object log records! {cnt=}"
-            assert len(target_records) == 1, f"Too many records! {cnt=}"
+            assert target_records, (
+                f"Did not find object log records! cnt={cnt}"
+            )
+            assert len(target_records) == 1, (
+                f"Too many records! cnt={cnt}"
+            )
             record = target_records[0]
             if not filtered or cnt == 0:
-                assert record.levelno == logging.ERROR, f"{filtered=}, {cnt=}"
+                assert record.levelno == logging.ERROR, (
+                    f"filtered={filtered}, cnt={cnt}"
+                )
             else:
-                assert record.levelno == logging.DEBUG, f"{filtered=}, {cnt=}"
+                assert record.levelno == logging.DEBUG, (
+                    f"filtered={filtered}, cnt={cnt}"
+                )
             assert "ZeroDivisionError" in record.exc_text
         if filtered:
             assert callback_demoter.counter == total_cnt - 1
@@ -208,7 +232,7 @@ def test_exception_non_duplicates(
     callback_demoter.only_duplicates = False
 
     def varied_exception(*args, value, **kwargs):
-        raise RuntimeError(f'Varied exception {value=}')
+        raise RuntimeError(f'Varied exception value={value}')
 
     sig = ophyd.Signal(name='sig')
     sig.subscribe(varied_exception, run=False)
@@ -222,13 +246,21 @@ def test_exception_non_duplicates(
             target_records = [
                 rec for rec in caplog.records if rec.name == 'ophyd.objects'
             ]
-            assert target_records, f"Did not find object log records! {cnt=}"
-            assert len(target_records) == 1, f"Too many records! {cnt=}"
+            assert target_records, (
+                f"Did not find object log records! cnt={cnt}"
+            )
+            assert len(target_records) == 1, (
+                f"Too many records! cnt={cnt}"
+            )
             record = target_records[0]
             if not filtered:
-                assert record.levelno == logging.ERROR, f"{filtered=}, {cnt=}"
+                assert record.levelno == logging.ERROR, (
+                    f"filtered={filtered}, cnt={cnt}"
+                )
             else:
-                assert record.levelno == logging.DEBUG, f"{filtered=}, {cnt=}"
+                assert record.levelno == logging.DEBUG, (
+                    f"filtered={filtered}, cnt={cnt}"
+                )
             assert "Varied exception" in record.exc_text
         if filtered:
             assert callback_demoter.counter == total_cnt

--- a/pcdsutils/tests/test_logging.py
+++ b/pcdsutils/tests/test_logging.py
@@ -179,14 +179,17 @@ def test_exception_filter(
         for cnt in range(total_cnt):
             caplog.clear()
             sig.put(cnt)
-            assert caplog.records, f"Did not find log records! {cnt=}"
-            assert len(caplog.records) == 1, f"Too many records! {cnt=}"
-            record = caplog.records[0]
+            target_records = [
+                rec for rec in caplog.records if rec.name == 'ophyd.objects'
+            ]
+            assert target_records, f"Did not find object log records! {cnt=}"
+            assert len(target_records) == 1, f"Too many records! {cnt=}"
+            record = target_records[0]
             if not filtered or cnt == 0:
-                assert record.levelno == logging.ERROR
+                assert record.levelno == logging.ERROR, f"{filtered=}, {cnt=}"
             else:
-                assert record.levelno == logging.DEBUG
-            assert "ZeroDivisionError" in record.message
+                assert record.levelno == logging.DEBUG, f"{filtered=}, {cnt=}"
+            assert "ZeroDivisionError" in record.exc_text
         if filtered:
             assert callback_demoter.counter == total_cnt - 1
         else:
@@ -216,14 +219,17 @@ def test_exception_non_duplicates(
         for cnt in range(total_cnt):
             caplog.clear()
             sig.put(cnt)
-            assert caplog.records, f"Did not find log records! {cnt=}"
-            assert len(caplog.records) == 1, f"Too many records! {cnt=}"
-            record = caplog.records[0]
+            target_records = [
+                rec for rec in caplog.records if rec.name == 'ophyd.objects'
+            ]
+            assert target_records, f"Did not find object log records! {cnt=}"
+            assert len(target_records) == 1, f"Too many records! {cnt=}"
+            record = target_records[0]
             if not filtered:
-                assert record.levelno == logging.ERROR
+                assert record.levelno == logging.ERROR, f"{filtered=}, {cnt=}"
             else:
-                assert record.levelno == logging.DEBUG
-            assert "Varied exception" in record.message
+                assert record.levelno == logging.DEBUG, f"{filtered=}, {cnt=}"
+            assert "Varied exception" in record.exc_text
         if filtered:
             assert callback_demoter.counter == total_cnt
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add a filter to demote the log level of https://github.com/bluesky/ophyd/blob/9e6c7de69a7bc6cc7e3b3c7273a5d3add9825513/ophyd/ophydobj.py#L466
- Refactor #37 such that these filters share common code, to avoid logic duplication
- Add option for demoting duplicates only vs all log messages
- Add counter for other tools to use to see how many log messages have been demoted

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The log message this targets is very likely to be a source of spam
- The configuration options give us choices for later when we apply these to hutch-python
- Ideas for using the counter: how many log messages were skipped during the scan? display the number of hidden messages in the prompt?
- Might be redundant with https://github.com/pcdshub/hutch-python/pull/298 but I think it's important to catch these messages after 1 or 0 showings instead of waiting to trip the circuit breaker

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Just docstrings for now

<!--
## Screenshots (if appropriate):
-->
