### PR TITLE
ENH: get current experiment

### DIFF
--- a/pcdsutils/ext_scripts.py
+++ b/pcdsutils/ext_scripts.py
@@ -3,6 +3,8 @@ import re
 import socket
 import subprocess
 
+from typing import Optional
+
 
 logger = logging.getLogger(__name__)
 CNF = '/reg/g/pcds/dist/pds/{0}/scripts/{0}.cnf'
@@ -126,6 +128,42 @@ def get_run_number(hutch=None, live=False, timeout=1):
         args += ['-l']
     run_number = call_script(args, timeout=timeout)
     return int(run_number)
+
+
+def get_current_experiment(
+    hutch: Optional[str] = None,
+    live: bool = False,
+    timeout: float = 1.,
+):
+    """
+    Call get_curr_exp to return the current experiment name.
+
+    Parameters
+    ----------
+    hutch : str, optional
+        The name of the hutch to get the experiment for. If omitted, the hutch
+        name will be determined automatically via cli argument.
+
+    live : bool, optional
+        Defaults to False. If True, we'll return the experiment of the current
+        run.
+
+    timeout : int or float, optional
+        Time to wait for get_curr_exp to finish.
+        Defaults to a 1 second timeout.
+
+    Returns
+    -------
+    experiment_name : str
+    """
+    args = [
+        SCRIPTS.format(hutch or "latest", "get_curr_exp")
+    ]
+    if hutch is not None:
+        args += ["-i", hutch]
+    if live:
+        args += ["-l"]
+    return (call_script(args, timeout=timeout) or "unknown").strip()
 
 
 def get_ami_proxy(hutch, timeout=10):

--- a/pcdsutils/ext_scripts.py
+++ b/pcdsutils/ext_scripts.py
@@ -2,9 +2,7 @@ import logging
 import re
 import socket
 import subprocess
-
 from typing import Optional
-
 
 logger = logging.getLogger(__name__)
 CNF = '/reg/g/pcds/dist/pds/{0}/scripts/{0}.cnf'
@@ -98,7 +96,11 @@ def get_hutch_name(timeout=10):
 hutch_name = get_hutch_name
 
 
-def get_run_number(hutch=None, live=False, timeout=1):
+def get_run_number(
+    hutch: Optional[str] = None,
+    live: bool = False,
+    timeout: float = 1.,
+):
     """
     Call get_lastRun to return the run number of the last daq run.
 
@@ -166,7 +168,7 @@ def get_current_experiment(
     return (call_script(args, timeout=timeout) or "unknown").strip()
 
 
-def get_ami_proxy(hutch, timeout=10):
+def get_ami_proxy(hutch: str, timeout: float = 10.):
     """
     Call procmgr to determine the lcls-I ami proxy hostname.
 

--- a/pcdsutils/tests/test_ext_scripts.py
+++ b/pcdsutils/tests/test_ext_scripts.py
@@ -32,6 +32,16 @@ def test_hutch_name(monkeypatch):
     assert ext.get_hutch_name() == 'tst'
 
 
+def test_experiment_name(monkeypatch):
+    logger.debug('test_experiment_name')
+
+    def fake_experiment_name(*args, **kwargs):
+        return 'tst\n'
+
+    monkeypatch.setattr(ext, 'call_script', fake_experiment_name)
+    assert ext.get_current_experiment() == 'tst'
+
+
 def test_run_number(monkeypatch):
     logger.debug('test_run_number')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Wrap the engineering tools script `get_curr_exp`.

## Motivation and Context
* It wasn't there, but we have a lesser version that should be replaced in hutch-python
* Some basic type hints

## How Has This Been Tested?
Test suite plus:
```
$ ipython -c "import pcdsutils.ext_scripts; print(pcdsutils.ext_scripts.get_current_experiment())"
xcsc00120
```

## Where Has This Been Documented?
PR text
