### PR TITLE
ENH: add ophyd helpers from typhos/atef

### DIFF
--- a/pcdsutils/ophyd.py
+++ b/pcdsutils/ophyd.py
@@ -1,0 +1,154 @@
+import contextlib
+import logging
+from typing import Callable, Optional
+
+import ophyd
+from ophyd.ophydobj import OphydObject
+
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol
+
+
+logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def subscription_context(
+    *objects: OphydObject,
+    callback: Callable,
+    event_type: Optional[str] = None,
+    run: bool = True
+):
+    """
+    [Context manager] Subscribe to a specific event from all objects
+
+    Unsubscribes all signals before exiting
+
+    Parameters
+    ----------
+    *objects : ophyd.OphydObj
+        Ophyd objects (signals) to monitor
+    callback : callable
+        Callback to run, with same signature as that of
+        :meth:`ophyd.OphydObj.subscribe`.
+    event_type : str, optional
+        The event type to subscribe to
+    run : bool, optional
+        Run the previously cached subscription immediately
+    """
+    obj_to_cid = {}
+    try:
+        for obj in objects:
+            try:
+                obj_to_cid[obj] = obj.subscribe(
+                    callback, event_type=event_type, run=run
+                )
+            except Exception:
+                logger.exception("Failed to subscribe to object %s", obj.name)
+        yield dict(obj_to_cid)
+    finally:
+        for obj, cid in obj_to_cid.items():
+            try:
+                obj.unsubscribe(cid)
+            except KeyError:
+                # It's possible that when the object is being torn down, or
+                # destroyed that this has already been done.
+                ...
+
+
+@contextlib.contextmanager
+def no_device_lazy_load():
+    '''
+    Context manager which disables the ophyd.device.Device
+    `lazy_wait_for_connection` behavior and later restore its value.
+    '''
+    old_val = ophyd.Device.lazy_wait_for_connection
+    try:
+        ophyd.Device.lazy_wait_for_connection = False
+        yield
+    finally:
+        ophyd.Device.lazy_wait_for_connection = old_val
+
+
+FilterBy = Callable[[ophyd.device.ComponentWalk], bool]
+
+
+def get_all_signals_from_device(
+    device: ophyd.Device,
+    include_lazy: bool = False,
+    filter_by: Optional[FilterBy] = None,
+):
+    """
+    Get all signals in a given device.
+
+    Parameters
+    ----------
+    device : ophyd.Device
+        ophyd Device to monitor
+    include_lazy : bool, optional
+        Include lazy signals as well
+    filter_by : callable, optional
+        Filter signals, with signature ``callable(ophyd.Device.ComponentWalk)``
+    """
+    def default_filter_by(*_) -> bool:
+        return True
+
+    filter_by = filter_by or default_filter_by
+
+    def _get_signals():
+        return [
+            walk.item
+            for walk in device.walk_signals(include_lazy=include_lazy)
+            if filter_by(walk)
+        ]
+
+    if not include_lazy:
+        return _get_signals()
+
+    with no_device_lazy_load():
+        return _get_signals()
+
+
+class SubscribeCallback(Protocol):
+    def __call__(self, **kwargs) -> None:
+        ...
+
+
+@contextlib.contextmanager
+def subscription_context_device(
+    device: ophyd.Device,
+    callback: SubscribeCallback,
+    event_type: Optional[str] = None,
+    run: bool = True,
+    *,
+    include_lazy: bool = False,
+    filter_by: Optional[FilterBy] = None
+):
+    """
+    [Context manager] Subscribe to ``event_type`` from signals in ``device``.
+
+    Unsubscribes all signals before exiting
+
+    Parameters
+    ----------
+    device : ophyd.Device
+        ophyd Device to monitor
+    callback : callable
+        Callback to run, with same signature as that of
+        :meth:`ophyd.OphydObj.subscribe`
+    event_type : str, optional
+        The event type to subscribe to
+    run : bool, optional
+        Run the previously cached subscription immediately
+    include_lazy : bool, optional
+        Include lazy signals as well
+    filter_by : callable, optional
+        Filter signals, with signature ``callable(ophyd.Device.ComponentWalk)``
+    """
+    signals = get_all_signals_from_device(device, include_lazy=include_lazy)
+    with subscription_context(
+        *signals, callback=callback, event_type=event_type, run=run
+    ) as obj_to_cid:
+        yield obj_to_cid

--- a/pcdsutils/tests/test_ophyd.py
+++ b/pcdsutils/tests/test_ophyd.py
@@ -1,0 +1,119 @@
+import ophyd
+from ophyd import Component as Cpt
+from ophyd import Device
+from ophyd.sim import SynSignal
+
+from .. import ophyd_helpers as helpers
+
+
+def test_no_device_lazy_load():
+    class TestDevice(Device):
+        c = Cpt(Device, suffix='Test')
+
+    dev = TestDevice(name='foo')
+
+    old_val = Device.lazy_wait_for_connection
+    assert dev.lazy_wait_for_connection is old_val
+    assert dev.c.lazy_wait_for_connection is old_val
+
+    with helpers.no_device_lazy_load():
+        dev2 = TestDevice(name='foo')
+
+        assert Device.lazy_wait_for_connection is False
+        assert dev2.lazy_wait_for_connection is False
+        assert dev2.c.lazy_wait_for_connection is False
+
+    assert Device.lazy_wait_for_connection is old_val
+    assert dev.lazy_wait_for_connection is old_val
+    assert dev.c.lazy_wait_for_connection is old_val
+
+
+def test_sub_context():
+    sig = SynSignal(name="sig")
+
+    def callback(**_):
+        ...
+
+    with helpers.subscription_context(sig, callback=callback) as ctx:
+        assert sig in ctx
+        assert len(sig._callbacks["value"])
+    assert not sig._callbacks["value"]
+
+
+def test_sub_context_device():
+    class TestDevice(Device):
+        a = Cpt(SynSignal)
+        b = Cpt(SynSignal)
+
+    def callback(**_):
+        ...
+
+    dev = TestDevice(name="dev")
+
+    with helpers.subscription_context_device(dev, callback=callback) as ctx:
+        assert len(dev.a._callbacks["value"])
+        assert len(dev.b._callbacks["value"])
+        assert dev.a in ctx
+        assert dev.b in ctx
+    assert not dev.a._callbacks["value"]
+    assert not dev.b._callbacks["value"]
+
+
+def test_sub_context_device_filter():
+    class TestDevice(Device):
+        a = Cpt(SynSignal)
+        b = Cpt(SynSignal)
+
+    def callback(**_):
+        ...
+
+    def filter_by(walk: ophyd.device.ComponentWalk) -> bool:
+        return walk.item.name == "dev_a"
+
+    dev = TestDevice(name="dev")
+
+    with helpers.subscription_context_device(
+        dev, callback=callback, filter_by=filter_by
+    ) as ctx:
+        assert len(dev.a._callbacks["value"])
+        assert not len(dev.b._callbacks["value"])
+        assert dev.a in ctx
+        assert dev.b not in ctx
+    assert not dev.a._callbacks["value"]
+    assert not dev.b._callbacks["value"]
+
+
+def test_get_all_signals():
+    class TestDevice(Device):
+        a = Cpt(SynSignal)
+        b = Cpt(SynSignal, lazy=True)
+
+    dev = TestDevice(name="dev")
+
+    assert helpers.get_all_signals_from_device(dev) == [dev.a]
+    assert helpers.get_all_signals_from_device(dev, include_lazy=True) == [
+        dev.a, dev.b
+    ]
+
+
+def test_get_all_signals_filter():
+    class TestDevice(Device):
+        a = Cpt(SynSignal)
+        b = Cpt(SynSignal)
+
+    dev = TestDevice(name="dev")
+
+    def filter_by(walk: ophyd.device.ComponentWalk) -> bool:
+        return walk.item.name == "dev_a"
+
+    assert helpers.get_all_signals_from_device(dev, filter_by=filter_by) == [
+        dev.a
+    ]
+
+
+def test_acquire_blocking():
+    sig = ophyd.Signal(name="sig")
+    sig.put(10)
+    values = helpers.acquire_blocking(sig, duration=0.05)
+    assert len(values) > 0
+    assert sig.get() in values

--- a/pcdsutils/type_hints.py
+++ b/pcdsutils/type_hints.py
@@ -1,0 +1,4 @@
+from typing import Union
+
+Number = Union[int, float]
+PrimitiveType = Union[str, int, bool, float]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 qtpy
 qtpyinheritance
 requests
+typing_extensions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Adds `no_device_lazy_load`:  Context manager which disables the ophyd.device.Device `lazy_wait_for_connection` behavior and later restore its value.
* Adds `subscription_context`:  Context manager which subscribes to a specific event from all provided objects, and unsubscribes after.
* Adds `subscription_context_device`:  Context manager which subscribes to a specific event from all matching signals on a device, and unsubscribes after.
* Adds `get_all_signals_from_device`: Gets all signals that match from a given device, with special lazy handling
* Adds `acquire_blocking` which subscribes to a signal for a period of time and returns all values acquired
* Adds `acquire_async` which does the same but for asyncio
* Adds `pcdsutils.type_hints` for common/reusable hints (considering to add reusable ones from elsewhere down the line)

## Motivation and Context
* This code is reusable and useful, so it belongs here.

## How Has This Been Tested?
* Included test suite.

## Where Has This Been Documented?
* This PR text and docstrings.
