### PR TITLE
ENH: import timing function using python built-in options

### DIFF
--- a/pcdsutils/import_timer.py
+++ b/pcdsutils/import_timer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
@@ -173,8 +174,10 @@ def get_import_time_text(module: str) -> List[str]:
 
     Returns the line-by-line std output from this call.
     """
+    if not sys.executable:
+        raise RuntimeError('Could not locate correct python executable.')
     return subprocess.check_output(
-        ['python', '-X', 'importtime', '-c', f'import {module}'],
+        [sys.executable, '-X', 'importtime', '-c', f'import {module}'],
         universal_newlines=True,
         stderr=subprocess.STDOUT,
     ).splitlines()

--- a/pcdsutils/import_timer.py
+++ b/pcdsutils/import_timer.py
@@ -70,7 +70,7 @@ class ImportTimeStats:
         self_time_raw, cumulative_time_raw, module = line.split('|')
         self_time_raw = int(self_time_raw.strip())
         cumulative_time_raw = int(cumulative_time_raw.strip())
-        indent_level = (module.count(' ') - 1) / 2
+        indent_level = (module.count(' ') - 1) // 2
         module = module.strip()
 
         return cls(

--- a/pcdsutils/import_timer.py
+++ b/pcdsutils/import_timer.py
@@ -3,8 +3,8 @@ Helpers for timing how long it takes to do various imports.
 """
 from __future__ import annotations
 
+import argparse
 import subprocess
-import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
@@ -258,4 +258,26 @@ def main(
 
 
 if __name__ == '__main__':
-    main(*sys.argv[1:])
+    parser = argparse.ArgumentParser(
+        description='Utility to identify modules that are slow to import.',
+    )
+    parser.add_argument(
+        'module',
+        help='The module name to import.',
+    )
+    parser.add_argument(
+        '--sort-key',
+        default='self_time',
+        help='The table header to sort on.',
+    )
+    parser.add_argument(
+        '--show-module',
+        default=None,
+        help='A specific module to show a breakdown for in the output.',
+    )
+    args = parser.parse_args()
+    main(
+        module=args.module,
+        sort_key=args.sort_key,
+        focus_on=args.show_module,
+    )

--- a/pcdsutils/import_timer.py
+++ b/pcdsutils/import_timer.py
@@ -1,0 +1,261 @@
+"""
+Helpers for timing how long it takes to do various imports.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from prettytable import PrettyTable
+
+
+@dataclass(frozen=True)
+class ImportTimeStats:
+    """
+    Stats about importing this module or submodule.
+
+    Attributes
+    ----------
+    module : str
+        The full import name, e.g. pcdsdevices.signal
+    root_module : str
+        The source module, e.g. pcdsdevices
+    self_time_raw : int
+        The time it took to import this module in microseconds, not counting
+        the time it took to import other modules.
+    self_time : float
+        The time it took to import this module in seconds, not counting
+        the time it took to import other modules.
+    cumulative_time_raw : int
+        The time it took to import this module in microseconds,
+        including the time it took to import other modules.
+    cumulative_time : float
+        The time it took to import this module in seconds,
+        including the time it took to import other modules.
+    indent_level : int
+        How deep this import was. An indent level of 0 indicates that
+        this was the main import or a python internal import used to set up
+        the import system itself. Each additional level means that this module
+        was imported by a module one level lower. For example, a module with
+        indent level 2 was imported by a module with import level 1.
+    """
+    module: str
+    root_module: str
+    self_time_raw: int
+    self_time: float
+    cumulative_time_raw: int
+    cumulative_time: float
+    indent_level: int
+
+    @classmethod
+    def from_line(cls, line: str) -> ImportTimeStats:
+        """
+        Assemble an ImportTimeStats from a python -X importtime output line.
+
+        Example lines:
+        import time:      2848 |       2848 |     pcdsdevices.stopper
+        import time:      7611 |      10459 |   pcdsdevices.valve
+        import time:      1859 |       1859 |   pcdsdevices.wfs
+        import time:      2913 |   12317383 | pcdsdevices.device_types
+        """
+        if not line.startswith('import time'):
+            raise ValueError(
+                f'Recieved {line}, which is not a valid importtime output.'
+            )
+        line = line.split('import time:')[1]
+        self_time_raw, cumulative_time_raw, module = line.split('|')
+        self_time_raw = int(self_time_raw.strip())
+        cumulative_time_raw = int(cumulative_time_raw.strip())
+        indent_level = (module.count(' ') - 1) / 2
+        module = module.strip()
+
+        return cls(
+            module=module,
+            root_module=module.split('.')[0],
+            self_time_raw=self_time_raw,
+            self_time=self_time_raw / 1e6,
+            cumulative_time_raw=cumulative_time_raw,
+            cumulative_time=cumulative_time_raw / 1e6,
+            indent_level=indent_level,
+        )
+
+
+@dataclass(frozen=True)
+class ModuleStatsSummary:
+    """
+    For a top-level module, the total time spent on all the submodules.
+
+    Attributes
+    ----------
+    root_module : str
+        The source module, e.g. pcdsdevices
+    self_time_raw : int
+        The time it took to import this module in microseconds, not counting
+        the time it took to import other modules.
+    self_time : float
+        The time it took to import this module in seconds, not counting
+        the time it took to import other modules.
+    cumulative_time_raw : int
+        The time it took to import this module in microseconds,
+        including the time it took to import other modules.
+    cumulative_time : float
+        The time it took to import this module in seconds,
+        including the time it took to import other modules.
+    submodule_stats : tuple of ImportTimeStats
+        The stats that were used to generate this stats summary.
+    """
+    root_module: str
+    self_time_raw: int
+    self_time: float
+    cumulative_time_raw: int
+    cumulative_time: float
+    submodule_stats: Tuple[ImportTimeStats]
+
+    @classmethod
+    def from_stats(cls, stats: List[ImportTimeStats]) -> ModuleStatsSummary:
+        """
+        Create a ModuleStatsSummary from a list of ImportTimeStats.
+        """
+        self_time_raw = 0
+        cumulative_time_raw = 0
+        for stat in stats:
+            self_time_raw += stat.self_time_raw
+            if stat.module == stat.root_module:
+                cumulative_time_raw = stat.cumulative_time_raw
+        return cls(
+            root_module=stats[0].root_module,
+            self_time_raw=self_time_raw,
+            self_time=self_time_raw / 1e6,
+            cumulative_time_raw=cumulative_time_raw,
+            cumulative_time=cumulative_time_raw / 1e6,
+            submodule_stats=tuple(stats),
+        )
+
+    def show_detailed_summary(self, sort_key: str = 'self_time') -> None:
+        """
+        For this module, explain the situation to stdout.
+        """
+        field_names = tuple(
+            field for field in ImportTimeStats.__dataclass_fields__
+            if 'raw' not in field
+        )
+        table = PrettyTable(
+            field_names=field_names,
+        )
+        table.add_row(
+            tuple(
+                getattr(self, attr, 'N/A')
+                for attr in field_names
+            )
+        )
+        for stats in sorted(
+            self.submodule_stats,
+            key=lambda s: getattr(s, sort_key),
+            reverse=True,
+        ):
+            table.add_row(
+                tuple(
+                    getattr(stats, attr)
+                    for attr in field_names
+                )
+            )
+        print(table)
+
+
+def get_import_time_text(module: str) -> List[str]:
+    """
+    Run python -X importtime modulename in a subprocess.
+
+    Returns the line-by-line std output from this call.
+    """
+    return subprocess.check_output(
+        ['python', '-X', 'importtime', '-c', f'import {module}'],
+        universal_newlines=True,
+        stderr=subprocess.STDOUT,
+    ).splitlines()
+
+
+def interpret_import_time(
+    stats: List[ImportTimeStats],
+) -> Dict[str, ModuleStatsSummary]:
+    """
+    Summarize the results of the import time checker in an understandable way.
+
+    The output is a dictionary of top-level module import name to a
+    ModuleStatsSummary instance that details how much time it took to import
+    that module.
+
+    Parameters
+    ----------
+    stats : list of ImportTimeStats
+        All of the stats objects from a particular importtime output.
+    """
+    stats_by_root_module = defaultdict(list)
+    for stat in stats:
+        stats_by_root_module[stat.root_module].append(stat)
+    summaries = {}
+    for root_module, stats in stats_by_root_module.items():
+        summaries[root_module] = ModuleStatsSummary.from_stats(stats)
+    return summaries
+
+
+def summarize_import_stats(module: str) -> Dict[str, ModuleStatsSummary]:
+    """
+    Summarize the import time statistics for a given module.
+    """
+    output = get_import_time_text(module)
+    stats = []
+    for line in output[1:]:
+        stats.append(ImportTimeStats.from_line(line))
+    return interpret_import_time(stats)
+
+
+def display_summarized_import_stats(
+    stats_summary: Dict[str, ModuleStatsSummary],
+    sort_key: str = 'self_time',
+    focus_on: Optional[str] = None,
+) -> None:
+    # When the user only cares about dissecting a specific module.
+    if focus_on is not None:
+        return stats_summary[focus_on].show_detailed_summary(sort_key)
+    # Sort and assemble a prettytable
+    field_names = tuple(
+        field for field in ModuleStatsSummary.__dataclass_fields__
+        if field != 'submodule_stats'
+        if 'raw' not in field
+    )
+    table = PrettyTable(
+        field_names=field_names,
+    )
+    for stats in sorted(
+        stats_summary.values(),
+        key=lambda s: getattr(s, sort_key),
+        reverse=True,
+    ):
+        table.add_row(
+            tuple(
+                getattr(stats, attr)
+                for attr in field_names
+            )
+        )
+    print(table)
+
+
+def main(
+    module: str,
+    sort_key: str = 'self_time',
+    focus_on: Optional[str] = None,
+) -> None:
+    stats_summary = summarize_import_stats(module)
+    display_summarized_import_stats(
+        stats_summary=stats_summary,
+        sort_key=sort_key,
+        focus_on=focus_on,
+    )
+
+
+if __name__ == '__main__':
+    main(*sys.argv[1:])

--- a/pcdsutils/import_timer.py
+++ b/pcdsutils/import_timer.py
@@ -317,7 +317,16 @@ def main(
     module: str,
     sort_key: str = 'self_time',
     focus_on: Optional[str] = None,
+    chain: Optional[str] = None,
 ) -> None:
+    if chain is not None:
+        print(f'Import chain for importing dependency {chain}:')
+        for submodule in get_import_chain(
+            module_to_import=module,
+            submodule_to_chain=chain,
+        ):
+            print(submodule)
+        return
     stats_summary = summarize_import_stats(module)
     display_summarized_import_stats(
         stats_summary=stats_summary,
@@ -344,9 +353,18 @@ if __name__ == '__main__':
         default=None,
         help='A specific module to show a breakdown for in the output.',
     )
+    parser.add_argument(
+        '--show-chain',
+        default=None,
+        help=(
+            'Instead, show the chain of imports that leads to a specific '
+            'dependency being imported.'
+        ),
+    )
     args = parser.parse_args()
     main(
         module=args.module,
         sort_key=args.sort_key,
         focus_on=args.show_module,
+        chain=args.show_chain,
     )

--- a/pcdsutils/import_timer.py
+++ b/pcdsutils/import_timer.py
@@ -113,7 +113,7 @@ class ModuleStatsSummary:
     self_time: float
     cumulative_time_raw: int
     cumulative_time: float
-    submodule_stats: Tuple[ImportTimeStats]
+    submodule_stats: Tuple[ImportTimeStats, ...]
 
     @classmethod
     def from_stats(cls, stats: List[ImportTimeStats]) -> ModuleStatsSummary:

--- a/pcdsutils/import_timer.py
+++ b/pcdsutils/import_timer.py
@@ -123,8 +123,10 @@ class ModuleStatsSummary:
         cumulative_time_raw = 0
         for stat in stats:
             self_time_raw += stat.self_time_raw
-            if stat.module == stat.root_module:
-                cumulative_time_raw = stat.cumulative_time_raw
+            cumulative_time_raw = max(
+                cumulative_time_raw,
+                stat.cumulative_time_raw,
+            )
         return cls(
             root_module=stats[0].root_module,
             self_time_raw=self_time_raw,

--- a/pcdsutils/import_timer.py
+++ b/pcdsutils/import_timer.py
@@ -204,9 +204,9 @@ def interpret_import_time(
     return summaries
 
 
-def summarize_import_stats(module: str) -> Dict[str, ModuleStatsSummary]:
+def get_import_stats(module: str) -> List[ImportTimeStats]:
     """
-    Summarize the import time statistics for a given module.
+    Get the import time statistics for a given module.
 
     Parameters
     ----------
@@ -217,7 +217,19 @@ def summarize_import_stats(module: str) -> Dict[str, ModuleStatsSummary]:
     stats = []
     for line in output[1:]:
         stats.append(ImportTimeStats.from_line(line))
-    return interpret_import_time(stats)
+    return stats
+
+
+def summarize_import_stats(module: str) -> Dict[str, ModuleStatsSummary]:
+    """
+    Summarize the import time statistics for a given module.
+
+    Parameters
+    ----------
+    module : str
+        The module to import.
+    """
+    return interpret_import_time(get_import_stats(module))
 
 
 def display_summarized_import_stats(
@@ -291,7 +303,14 @@ def get_import_chain(
         you imported and ending with the submodule you're trying to track
         down.
     """
-    ...
+    chain = []
+    for stats in get_import_stats(module_to_import):
+        if stats.module == submodule_to_chain:
+            chain = [stats]
+        elif chain:
+            if stats.indent_level < chain[0].indent_level:
+                chain.insert(0, stats)
+    return [stats.module for stats in chain]
 
 
 def main(

--- a/pcdsutils/import_timer.py
+++ b/pcdsutils/import_timer.py
@@ -145,12 +145,12 @@ class ModuleStatsSummary:
         table = PrettyTable(
             field_names=field_names,
         )
-        table.add_row(
-            tuple(
-                getattr(self, attr, 'N/A')
-                for attr in field_names
-            )
+        summary_row = list(
+            getattr(self, attr, 'N/A')
+            for attr in field_names
         )
+        summary_row[0] = 'Total'
+        table.add_row(summary_row)
         for stats in sorted(
             self.submodule_stats,
             key=lambda s: getattr(s, sort_key),

--- a/pcdsutils/import_timer.py
+++ b/pcdsutils/import_timer.py
@@ -338,7 +338,7 @@ def main(
     )
 
 
-if __name__ == '__main__':
+def _entrypoint():
     parser = argparse.ArgumentParser(
         description='Utility to identify modules that are slow to import.',
     )
@@ -371,3 +371,7 @@ if __name__ == '__main__':
         focus_on=args.show_module,
         chain=args.show_chain,
     )
+
+
+if __name__ == '__main__':
+    _entrypoint()

--- a/pcdsutils/import_timer.py
+++ b/pcdsutils/import_timer.py
@@ -207,6 +207,11 @@ def interpret_import_time(
 def summarize_import_stats(module: str) -> Dict[str, ModuleStatsSummary]:
     """
     Summarize the import time statistics for a given module.
+
+    Parameters
+    ----------
+    module : str
+        The module to import.
     """
     output = get_import_time_text(module)
     stats = []
@@ -220,6 +225,21 @@ def display_summarized_import_stats(
     sort_key: str = 'self_time',
     focus_on: Optional[str] = None,
 ) -> None:
+    """
+    Show a prettytable summary of all the import statistics.
+
+    Parameters
+    ----------
+    stats_summary : dict[str, ModuleStatsSummary]
+        The output from summarize_import_stats. This is a mapping from
+        root module name to the module stats summary objects.
+    sort_key : str, optional
+        The key to sort the output table on.
+    focus_on : str, optional
+        A module to focus on for the output. If provided, we'll show
+        a detailed breakdown of that module instead of the big table
+        of all the imported modules.
+    """
     # When the user only cares about dissecting a specific module.
     if focus_on is not None:
         return stats_summary[focus_on].show_detailed_summary(sort_key)
@@ -244,6 +264,34 @@ def display_summarized_import_stats(
             )
         )
     print(table)
+
+
+def get_import_chain(
+    module_to_import: str,
+    submodule_to_chain: str,
+) -> List[str]:
+    """
+    For a given import, figure out why a specific submodule is being imported.
+
+    The return value is a list of modules that import each other in order,
+    starting with the module you imported and ending with the submodule you're
+    trying to track down.
+
+    Parameters
+    ----------
+    module_to_import : str
+        The module you are trying to import.
+    submodule_to_chain : str
+        The submodule that gets imported that you need to track down.
+
+    Returns
+    -------
+    module_chain : list of str
+        The modules that import each other in order, starting with the module
+        you imported and ending with the submodule you're trying to track
+        down.
+    """
+    ...
 
 
 def main(

--- a/pcdsutils/tests/test_import_timer.py
+++ b/pcdsutils/tests/test_import_timer.py
@@ -1,0 +1,100 @@
+from ..import_timer import (ImportTimeStats, ModuleStatsSummary,
+                            display_summarized_import_stats, get_import_chain,
+                            get_import_stats, get_import_time_text,
+                            interpret_import_time, main,
+                            summarize_import_stats)
+
+
+def test_import_time_stats_from_line():
+    line = 'import time:      1848 |       2848 |     pcdsdevices.stopper'
+    stats = ImportTimeStats.from_line(line)
+    assert stats.module == 'pcdsdevices.stopper'
+    assert stats.root_module == 'pcdsdevices'
+    assert stats.self_time_raw == 1848
+    assert stats.self_time == 0.001848
+    assert stats.cumulative_time_raw == 2848
+    assert stats.cumulative_time == 0.002848
+    assert stats.indent_level == 2
+
+
+def test_module_stats_summary_from_stats():
+    stats = ImportTimeStats(
+        module='pcdsdevices.signal',
+        root_module='pcdsdevices',
+        self_time_raw=1000,
+        self_time=0.001,
+        cumulative_time_raw=2000,
+        cumulative_time=0.002,
+        indent_level=1,
+    )
+    summary = ModuleStatsSummary.from_stats([stats, stats, stats])
+    assert summary.root_module == 'pcdsdevices'
+    assert summary.self_time_raw == 3000
+    assert summary.self_time == 0.003
+    assert summary.cumulative_time_raw == 2000
+    assert summary.cumulative_time == 0.002
+    assert summary.submodule_stats == tuple([stats, stats, stats])
+    summary.show_detailed_summary()
+
+
+def test_get_import_time_text():
+    text = get_import_time_text('sys')
+    assert len(text) > 10
+    for line in text:
+        assert line.startswith('import time:')
+
+
+def test_interpret_import_time():
+    stats1 = ImportTimeStats(
+        module='pcdsdevices.signal',
+        root_module='pcdsdevices',
+        self_time_raw=1000,
+        self_time=0.001,
+        cumulative_time_raw=2000,
+        cumulative_time=0.002,
+        indent_level=1,
+    )
+    stats2 = ImportTimeStats(
+        module='ophyd.signal',
+        root_module='ophyd',
+        self_time_raw=1000,
+        self_time=0.001,
+        cumulative_time_raw=2000,
+        cumulative_time=0.002,
+        indent_level=1,
+    )
+    summaries = interpret_import_time(
+        [stats1, stats2, stats1, stats2, stats2]
+    )
+    assert len(summaries['pcdsdevices'].submodule_stats) == 2
+    assert len(summaries['ophyd'].submodule_stats) == 3
+
+
+def test_get_import_stats_smoke():
+    # No specifics in this test, the output differs for different envs
+    get_import_stats('sys')
+
+
+def test_summarize_import_stats():
+    # No specifics in this test, the output differs for different envs
+    summarize_import_stats('sys')
+
+
+def test_display_summarized_import_stats():
+    # No specifics in this test, the output differs for different envs
+    summaries = summarize_import_stats('pcdsutils')
+    display_summarized_import_stats(summaries)
+    display_summarized_import_stats(summaries, focus_on='pcdsutils')
+
+
+def test_get_import_chain():
+    # No specifics in this test, the output differs for different envs
+    get_import_chain('pcdsutils', 'sys')
+
+
+def test_main():
+    # No specifics in this test, the output differs for different envs
+    main('sys')
+    main('sys', sort_key='cumulative_time')
+    main('pcdsutils', focus_on='pcdsutils')
+    main('pcdsutils.import_timer', chain='typing')

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ console_scripts = [
     "requirements-from-conda=pcdsutils.requirements:_requirements_from_conda",
     "requirements-compare=pcdsutils.requirements:_compare_requirements",
     "json-to-table=pcdsutils.json_to_table:_entrypoint",
+    "import-timer=pcdsutils.import_timer:_entrypoint",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,16 @@ if git_requirements:
 
 
 console_scripts = [
-    "requirements-from-conda=pcdsutils.requirements:_requirements_from_conda",
-    "requirements-compare=pcdsutils.requirements:_compare_requirements",
     "json-to-table=pcdsutils.json_to_table:_entrypoint",
-    "import-timer=pcdsutils.import_timer:_entrypoint",
+    "pcdsutils-import-timer=pcdsutils.import_timer:_entrypoint",
+    (
+        "pcdsutils-requirements-compare"
+        "=pcdsutils.requirements:_compare_requirements"
+    ),
+    (
+        "pcdsutils-requirements-from-conda"
+        "=pcdsutils.requirements:_requirements_from_conda"
+    ),
 ]
 
 setup(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- build a table that shows which sub-imports take the most time when you do an import
- for a specific module, breakdown which submodules are taking up the most time
- for a specific import, trace where its being imported from

This is fairly accurate for the "time spent in this module" summaries and the import chaining, but has some inaccuracies with the "cumulative" timings that I don't want to rewrite the module to fix since that wasn't my main focus here. Namely, the true cumulative timing summary for a library may be split across the importtime output and may need a `max` at each split and a `sum` between splits but I've ignored that complexity entirely because I don't care about that number very much.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When you set up a single happi device, it takes a while just on imports.
I want to be able to identify modules that are slow to import and whether its their dependencies are slow or if its the module itself.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests and tested interactively for usability

```
$ python -m pcdsutils.import_timer pcdsdevices.mirror
+----------------------------+-----------+-----------------+
|        root_module         | self_time | cumulative_time |
+----------------------------+-----------+-----------------+
|       pkg_resources        |  0.493448 |     0.561669    |
|           ophyd            |  0.289937 |     0.443529    |
|           pandas           |  0.285818 |     0.309887    |
|         pcdsutils          |  0.251296 |     0.252413    |
|          networkx          |  0.157771 |     0.166776    |
|           numpy            |  0.139471 |     0.137027    |
|           scipy            |  0.128355 |     0.075882    |
|           fsspec           |  0.119466 |     0.155977    |
```
```
$ python -m pcdsutils.import_timer pcdsdevices.mirror --show-module pcdsdevices
+---------------------------+-------------+-----------+-----------------+--------------+
|           module          | root_module | self_time | cumulative_time | indent_level |
+---------------------------+-------------+-----------+-----------------+--------------+
|           Total           | pcdsdevices |  0.034066 |     2.706177    |     N/A      |
|  pcdsdevices.epics_motor  | pcdsdevices |  0.007277 |     0.357652    |     1.0      |
|     pcdsdevices.mirror    | pcdsdevices |  0.006674 |     2.706177    |     0.0      |
|     pcdsdevices.state     | pcdsdevices |  0.003374 |     0.003374    |     2.0      |
|   pcdsdevices.pseudopos   | pcdsdevices |  0.002355 |     0.009224    |     2.0      |
|   pcdsdevices.interface   | pcdsdevices |  0.002197 |      0.0706     |     3.0      |
|     pcdsdevices.signal    | pcdsdevices |  0.001978 |     1.194851    |     2.0      |
```
```
$ python -m pcdsutils.import_timer pcdsdevices.mirror --show-chain ophyd.areadetector.plugins
Import chain for importing dependency ophyd.areadetector.plugins:
pcdsdevices.mirror
pcdsdevices
ophyd.device
ophyd
ophyd.mca
ophyd.areadetector
ophyd.areadetector.cam
ophyd.areadetector.plugins
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

<!--
## Screenshots (if appropriate):
-->
