### PR TITLE
FIX: don't log SyntaxError/NameError

### DIFF
--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -26,7 +26,8 @@ logger.propagate = False
 # Exceptions that should just be ignored entirely:
 NO_LOG_EXCEPTIONS = (
     KeyboardInterrupt,
-    SyntaxError,
+    NameError,
+    SyntaxError,  # This doesn't get propagated, but ignore it anyway
     SystemExit,
 )
 

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -24,7 +24,11 @@ logger = logging.getLogger('pcds-logging')
 logger.propagate = False
 
 # Exceptions that should just be ignored entirely:
-NO_LOG_EXCEPTIONS = (KeyboardInterrupt, SystemExit)
+NO_LOG_EXCEPTIONS = (
+    KeyboardInterrupt,
+    SyntaxError,
+    SystemExit,
+)
 
 DEFAULT_LOG_HOST = os.environ.get('PCDS_LOG_HOST', 'ctl-logsrv01.pcdsn')
 DEFAULT_LOG_PORT = int(os.environ.get('PCDS_LOG_PORT', 54320))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Don't log `NameError` to the centralized logging system.
`SyntaxError` is included for good measure, but we don't actually see it with IPython catching it first.

## Motivation and Context
It's not useful for us
Closes #61 

## How Has This Been Tested?
Not tested

## Where Has This Been Documented?
Issue + PR text