### PR TITLE
MAINT: bulk secrets and readme update

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   standard:
     uses: pcdshub/pcds-ci-helpers/.github/workflows/python-standard.yml@master
+    secrets: inherit
     with:
       package-name: "pcdsutils"
       # Testing extras for both conda/pip jobs:


### PR DESCRIPTION
In all repos:
- Add secrets: inherit to the gh workflow so that the workflow has access to the pypi token on tag
- If the repo has a README.md, ensure that it is packaged correctly in pyproject.toml