### PR TITLE
ENH: add entrypoint for get-info-json

### DIFF
--- a/pcdsutils/info.py
+++ b/pcdsutils/info.py
@@ -114,7 +114,9 @@ class Experiment(_LogbookInfo):
 
     @classmethod
     def from_logbook(
-        cls, instrument: Instrument, experiment_name: Optional[str] = None
+        cls,
+        instrument: Instrument,
+        experiment_name: Optional[str] = None,
     ) -> Experiment:
         """
         Get Experiment information given an instrument/experiment name.
@@ -364,7 +366,10 @@ def get_hutch_by_hostname(hostname: Optional[str] = None) -> str:
     if hostname is None:
         hostname = socket.gethostname()
 
-    ip = socket.gethostbyname(hostname)
+    try:
+        ip = socket.gethostbyname(hostname)
+    except Exception:
+        return UNKNOWN_HUTCH
 
     # A.B.**C**.D - the C octet
     subnet = ip.split(".")[2]
@@ -458,7 +463,7 @@ def get_info(args: ProgramArguments) -> Optional[Instrument]:
 def main():
     """Main entrypoint for get-info-json."""
     parser = _create_arg_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(namespace=ProgramArguments())
     info = get_info(args)
     if info is None:
         sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ file = "LICENSE"
 
 [project.scripts]
 json-to-table = "pcdsutils.json_to_table:_entrypoint"
+pcdsutils-get-info-json = "pcdsutils.info:main"
 pcdsutils-import-timer = "pcdsutils.import_timer:_entrypoint"
 pcdsutils-requirements-compare = "pcdsutils.requirements:_compare_requirements"
 pcdsutils-requirements-from-conda = "pcdsutils.requirements:_requirements_from_conda"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add `pcdsutils-get-info-json` entrypoint (named as such to avoid a generic "get-info-json" binary in non-ECS installations; am willing to change after discussion). Name based on https://github.com/pcdshub/engineering_tools/blob/master/scripts/get_info

## Motivation and Context
* #51 brought get-info-json into pcdsutils after a year of sitting idle
* This aims to make it useful or at least add notes about the weird parts previous reviewers found

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
PR for now; dotfiles/confluence/sphinx later?

## Screenshots

<img width="520" alt="image" src="https://github.com/pcdshub/pcdsutils/assets/5139267/036a0fe6-e55c-460b-aa37-47ef351c3148">
