### PR TITLE
DOC: add API docs + pre-release note scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
     -   id: flake8
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
   - pcdsutils
   - pcdsutils.qt
   requires:
-  - line_profiler<4
+  - line_profiler
   - ophyd
   - pyqt=5
   - pytest >=6.2.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,4 @@ ophyd
 pytest>=6.2.0
 pytest-qt
 pyqt5
-line_profiler<4
+line_profiler

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,6 +1,7 @@
-sphinx
+docs-versions-menu
 ipython
 numpydoc
+sphinx
 sphinx-copybutton
 sphinx_rtd_theme
 sphinxcontrib-jquery

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,5 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
+	python update_api_list.py > $(SOURCEDIR)/api.rst
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/pre-release-notes.sh
+++ b/docs/pre-release-notes.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+ISSUE=$1
+shift
+DESCRIPTION=$*
+
+if [[ -z "$ISSUE" || -z "$DESCRIPTION" ]]; then
+    echo "Usage: $0 (ISSUE NUMBER) (DESCRIPTION)"
+    exit 1
+fi
+
+re_issue_number='^[1-9][0-9]*$'
+
+if ! [[ "$ISSUE" =~ $re_issue_number ]]; then
+    echo "Error: Issue number is not a number: $ISSUE"
+    echo
+    echo "This should preferably be the issue number that this pull request solves."
+    echo "We may also accept the Pull Request number in place of the issue."
+    exit 1
+fi
+
+echo "Issue: $ISSUE"
+echo "Description: $DESCRIPTION"
+
+FILENAME=source/upcoming_release_notes/${ISSUE}-${DESCRIPTION// /_}.rst
+
+pushd "$(dirname "$0")" || exit 1
+
+sed -e "s/IssueNumber Title/${ISSUE} ${DESCRIPTION}/" \
+    "source/upcoming_release_notes/template-short.rst" > "${FILENAME}"
+
+if ${EDITOR} "${FILENAME}"; then
+    echo "Adding ${FILENAME} to the git repository..."
+    git add "${FILENAME}"
+fi
+
+popd || exit 0

--- a/docs/release_notes.py
+++ b/docs/release_notes.py
@@ -1,0 +1,114 @@
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+# find the pre-release directory and release notes file
+THIS_DIR = Path(__file__).resolve().parent
+PRE_RELEASE = THIS_DIR / 'source' / 'upcoming_release_notes'
+TEMPLATE = PRE_RELEASE / 'template-short.rst'
+RELEASE_NOTES = THIS_DIR / 'source' / 'releases.rst'
+
+# Set up underline constants
+TITLE_UNDER = '#'
+RELEASE_UNDER = '='
+SECTION_UNDER = '-'
+
+
+def parse_pre_release_file(path):
+    """
+    Return dict mapping of release notes section to lines.
+
+    Uses empty list when no info was entered for the section.
+    """
+    print(f'Checking {path} for release notes.')
+    with path.open('r') as fd:
+        lines = fd.readlines()
+
+    section_dict = defaultdict(list)
+    prev = None
+    section = None
+
+    for line in lines:
+        if prev is not None:
+            if line.startswith(SECTION_UNDER * 2):
+                section = prev.strip()
+                continue
+            if section is not None and line[0] in ' -':
+                notes = section_dict[section]
+                if len(line) > 6:
+                    notes.append(line)
+                section_dict[section] = notes
+        prev = line
+
+    return section_dict
+
+
+def extend_release_notes(path, version, release_notes):
+    """
+    Given dict mapping of section to lines, extend the release notes file.
+    """
+    with path.open('r') as fd:
+        lines = fd.readlines()
+
+    new_lines = ['\n', '\n']
+    date = time.strftime('%Y-%m-%d')
+    release_title = f'{version} ({date})'
+    new_lines.append(release_title + '\n')
+    new_lines.append(len(release_title) * RELEASE_UNDER + '\n')
+    new_lines.append('\n')
+    for section, section_lines in release_notes.items():
+        if section == 'Contributors':
+            section_lines = sorted(list(set(section_lines)))
+        if len(section_lines) > 0:
+            new_lines.append(section + '\n')
+            new_lines.append(SECTION_UNDER * len(section) + '\n')
+            new_lines.extend(section_lines)
+            new_lines.append('\n')
+
+    output_lines = lines[:2] + new_lines + lines[2:]
+
+    print('Writing out release notes file')
+    for line in new_lines:
+        print(line.strip('\n'))
+    with path.open('w') as fd:
+        fd.writelines(output_lines)
+
+
+def main(version_number: str):
+    section_notes = parse_pre_release_file(TEMPLATE)
+    to_delete = []
+    for path in PRE_RELEASE.iterdir():
+        if path.name[0] in '1234567890':
+            to_delete.append(path)
+            extra_notes = parse_pre_release_file(path)
+            for section, notes in section_notes.items():
+                notes.extend(extra_notes[section])
+                section_notes[section] = notes
+
+    extend_release_notes(RELEASE_NOTES, version_number, section_notes)
+
+    print(
+        "* Wrote release notes.  Please perform the following manually:",
+        file=sys.stderr,
+    )
+    for path in to_delete:
+        print(f" git rm {path}", file=sys.stderr)
+    print(f" git add {RELEASE_NOTES}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} VERSION_NUMBER", file=sys.stderr)
+        sys.exit(1)
+
+    version_number = sys.argv[1]
+
+    if not version_number.startswith("v"):
+        print(
+            f"Version number should start with 'v': {version_number}",
+            file=sys.stderr
+        )
+        sys.exit(1)
+
+    main(version_number)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,7 @@ release = ""
 # ones.
 extensions = [
     "sphinxcontrib.jquery",
+    "sphinx.ext.autosummary",
     "sphinx.ext.autodoc",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,8 +7,12 @@ Welcome to pcdsutils's documentation!
 ===========================================================
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+   :maxdepth: 1
+   :caption: Developer Notes
+
+   releases.rst
+   upcoming_changes.rst
+   api.rst
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,0 +1,242 @@
+=================
+ Release History
+=================
+
+
+v0.12.2 (2023-04-20)
+====================
+
+This is a maintenance release, there are no functional changes to the
+code in this release
+
+What’s Changed
+--------------
+
+-  MAINT: bulk secrets and readme update by @ZLLentz in
+   https://github.com/pcdshub/pcdsutils/pull/71
+
+
+v0.12.1 (2023-02-23)
+====================
+
+This is a maintenance/ci-only release. There are no functional changes
+to the library code.
+
+What’s Changed
+--------------
+
+-  CI: move to GitHub actions by @klauer in
+   https://github.com/pcdshub/pcdsutils/pull/69
+-  DEV/MNT: migrate to latest standards with pyproject.toml [LCLSPC-603]
+   by @klauer in https://github.com/pcdshub/pcdsutils/pull/70
+
+
+v0.12.0 (2022-11-16)
+====================
+
+What’s Changed
+--------------
+
+-  MAINT: scripted fix for precommit by @ZLLentz in
+   https://github.com/pcdshub/pcdsutils/pull/68
+-  ENH: include slightly tweaked DesignerDisplay from atef by @ZLLentz
+   in https://github.com/pcdshub/pcdsutils/pull/67
+
+
+v0.11.0 (2022-07-14)
+====================
+
+What’s Changed
+--------------
+
+-  FIX: classmethods and staticmethods in profiler by @ZLLentz in
+   https://github.com/pcdshub/pcdsutils/pull/59
+-  ENH: import timing function using python built-in options by @ZLLentz
+   in https://github.com/pcdshub/pcdsutils/pull/60
+-  FIX: don’t log SyntaxError/NameError by @klauer in
+   https://github.com/pcdshub/pcdsutils/pull/62
+-  ENH: log exception filename/line number by @klauer in
+   https://github.com/pcdshub/pcdsutils/pull/65
+
+
+v0.10.0 (2022-06-02)
+====================
+
+What’s Changed
+--------------
+
+-  ENH: profile utils from typhos by @ZLLentz in
+   https://github.com/pcdshub/pcdsutils/pull/47
+-  ENH: Profiler follow up by @ZLLentz in
+   https://github.com/pcdshub/pcdsutils/pull/53
+-  ENH: add LazyWidget by @klauer in
+   https://github.com/pcdshub/pcdsutils/pull/55
+
+
+v0.9.0 (2022-04-29)
+===================
+
+What’s Changed
+--------------
+
+-  ENH: json-to-table by @klauer in
+   https://github.com/pcdshub/pcdsutils/pull/49
+-  STY/FIX: pre commit by @klauer in
+   https://github.com/pcdshub/pcdsutils/pull/50
+
+
+v0.8.0 (2022-03-11)
+===================
+
+What’s Changed
+--------------
+
+-  ENH: add ophyd helpers from typhos/atef by @klauer in
+   https://github.com/pcdshub/pcdsutils/pull/46
+
+
+v0.7.0 (2022-02-02)
+===================
+
+What’s Changed
+--------------
+
+-  ENH: get current experiment by @klauer in
+   https://github.com/pcdshub/pcdsutils/pull/43
+-  BUG: prospective fix for demotion filter ignoring handler log level
+   by @ZLLentz in https://github.com/pcdshub/pcdsutils/pull/42
+-  ENH: HelpfulIntEnum by @klauer in
+   https://github.com/pcdshub/pcdsutils/pull/44
+
+Summary
+-------
+
+-  Add utilities that originated in other pcds libraries
+-  Fix a bug in the demotion filter
+
+
+v0.6.0 (2021-11-08)
+===================
+
+What’s Changed
+--------------
+
+-  ENH: add tools for using python logging for warning handling by
+   @ZLLentz in https://github.com/pcdshub/pcdsutils/pull/37
+-  ENH: Add callback exception deduplication filter by @ZLLentz in
+   https://github.com/pcdshub/pcdsutils/pull/39
+
+Summary
+-------
+
+Added utilities for demoting the level of log messages and for
+redirecting the warnings module to use the logging mechanisms. Most
+relevant additions:
+
+- ``pcdsutils.log.install_log_warning_handler``
+- ``pcdsutils.log.DemotionFilter``
+- ``pcdsutils.log.LogWarningLevelFilter``
+- ``pcdsutils.log.OphydCallbackExceptionDemoter``
+
+
+v0.5.0 (2021-07-22)
+===================
+
+Features
+--------
+
+-  Add central exception logging utilities that had previously been
+   duplicated in both hutch-python and lucid.
+
+Bugfixes
+--------
+
+-  Fix issues with the version difference display
+
+
+v0.4.3 (2021-07-09)
+===================
+
+Set the default log protocol to TCP, rather than UDP, so it works on
+hutch machines. Large UDP packets do not make it from hutch consoles to
+the log hosts.
+
+
+v0.4.2 (2021-03-23)
+===================
+
+-  Add missing username field to logger messages
+-  Fix dependency issues
+
+
+v0.4.1 (2021-01-19)
+===================
+
+Maintenance release, with CI and documentation updates.
+No functional changes to the code.
+
+
+v0.4.0 (2020-10-19)
+===================
+
+Features
+========
+
+-  Add release notes utility that converts from Github releases to
+   ``release_notes.rst`` for documentation.
+-  Transplant bash script interfaces from ``pcdsdaq`` as a more central
+   place to keep them. These currently include ``get_hutch_name``,
+   ``get_run_number`` and ``get_ami_proxy``
+
+
+v0.3.1 (2020-09-17)
+===================
+
+-  Do not propagate central logger records to root. Central logger
+   should only be shipping out to logstash, regardless of the root
+   logging configuration.
+
+
+v0.3.0 (2020-06-08)
+===================
+
+-  Improvements to ``requirements-compare``:
+
+   -  Add ``--ignore-docs`` to which makes differences at the
+      docs-requirements not a critical error
+   -  Set exit code to 1 in case requirements are not matching
+
+
+v0.2.0 (2020-05-15)
+===================
+
+-  Add requirements file-related utilities (comparison of
+   ``requirements.txt`` and conda ``meta.yaml``)
+
+   -  Adds console utilities ``requirements-from-conda``
+   -  Adds console utility ``requirements-compare``
+
+-  Relies on ``qtpynodeeditor`` for inheriting superclass properties
+
+
+v0.1.1 (2020-03-13)
+===================
+
+Fixes win32 ``os.uname`` issue
+
+
+v0.1.0 (2020-03-13)
+===================
+
+-  Interface to PCDS-wide logstash-based logging system
+-  Qt tools
+-  PopBar
+-  Property forwarder
+
+
+v0.0.0 (2020-01-24)
+===================
+
+Enjoy all of the features of *pcdsutils*:
+
+- TODO

--- a/docs/source/upcoming_changes.rst
+++ b/docs/source/upcoming_changes.rst
@@ -1,0 +1,8 @@
+Upcoming Changes
+################
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   upcoming_release_notes/[0-9]*

--- a/docs/source/upcoming_release_notes/51-add-get-info-json.rst
+++ b/docs/source/upcoming_release_notes/51-add-get-info-json.rst
@@ -1,0 +1,31 @@
+51 add-get-info-json
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add cleaned up and performant version of heavily-used ``get_info`` in
+  :mod:`pcdsutils.info`.
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Documentation building was fixed and pre-release note support was added.
+
+Contributors
+------------
+- klauer

--- a/docs/source/upcoming_release_notes/51-add-get-info-json.rst
+++ b/docs/source/upcoming_release_notes/51-add-get-info-json.rst
@@ -10,10 +10,6 @@ Features
 - Add cleaned up and performant version of heavily-used ``get_info`` in
   :mod:`pcdsutils.info`.
 
-Device Updates
---------------
-- N/A
-
 New Devices
 -----------
 - N/A

--- a/docs/source/upcoming_release_notes/51-add-get-info-json.rst
+++ b/docs/source/upcoming_release_notes/51-add-get-info-json.rst
@@ -10,10 +10,6 @@ Features
 - Add cleaned up and performant version of heavily-used ``get_info`` in
   :mod:`pcdsutils.info`.
 
-New Devices
------------
-- N/A
-
 Bugfixes
 --------
 - N/A

--- a/docs/source/upcoming_release_notes/template-full.rst
+++ b/docs/source/upcoming_release_notes/template-full.rst
@@ -1,0 +1,44 @@
+IssueNumber Title
+#################
+
+Update the title above with your issue number and a 1-2 word title.
+Your filename should be issuenumber-title.rst, substituting appropriately.
+
+Make sure to fill out any section that represents changes you have made,
+or replace the default bullet point with N/A.
+
+API Changes
+-----------
+- List backwards-incompatible changes here.
+  Changes to PVs don't count as API changes for this library,
+  but changing method and component names or changing default behavior does.
+
+Features
+--------
+- List new updates that add utility to many classes,
+  provide a new base classes, add options to helper methods, etc.
+
+Device Updates
+--------------
+- List new features or specific changes for individual devices.
+
+New Devices
+-----------
+- List new device support that is being added.
+
+Bugfixes
+--------
+- List bug fixes that are not covered in the above sections.
+
+Maintenance
+-----------
+- List anything else. The intent is to accumulate changes
+  that the average user does not need to worry about.
+
+Contributors
+------------
+- List your github username and anyone else who made significant
+  code or conceptual contributions to the PR. You don't need to
+  add reviewers unless their suggestions lead to large rewrites.
+  These will be used in the release notes to give credit and to
+  notify you when your code is being tagged.

--- a/docs/source/upcoming_release_notes/template-full.rst
+++ b/docs/source/upcoming_release_notes/template-full.rst
@@ -18,10 +18,6 @@ Features
 - List new updates that add utility to many classes,
   provide a new base classes, add options to helper methods, etc.
 
-Device Updates
---------------
-- List new features or specific changes for individual devices.
-
 Bugfixes
 --------
 - List bug fixes that are not covered in the above sections.

--- a/docs/source/upcoming_release_notes/template-full.rst
+++ b/docs/source/upcoming_release_notes/template-full.rst
@@ -22,10 +22,6 @@ Device Updates
 --------------
 - List new features or specific changes for individual devices.
 
-New Devices
------------
-- List new device support that is being added.
-
 Bugfixes
 --------
 - List bug fixes that are not covered in the above sections.

--- a/docs/source/upcoming_release_notes/template-short.rst
+++ b/docs/source/upcoming_release_notes/template-short.rst
@@ -1,0 +1,30 @@
+IssueNumber Title
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Device Updates
+--------------
+- N/A
+
+New Devices
+-----------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- N/A

--- a/docs/source/upcoming_release_notes/template-short.rst
+++ b/docs/source/upcoming_release_notes/template-short.rst
@@ -9,10 +9,6 @@ Features
 --------
 - N/A
 
-New Devices
------------
-- N/A
-
 Bugfixes
 --------
 - N/A

--- a/docs/source/upcoming_release_notes/template-short.rst
+++ b/docs/source/upcoming_release_notes/template-short.rst
@@ -9,10 +9,6 @@ Features
 --------
 - N/A
 
-Device Updates
---------------
-- N/A
-
 New Devices
 -----------
 - N/A

--- a/docs/update_api_list.py
+++ b/docs/update_api_list.py
@@ -23,7 +23,7 @@ def find_submodules(
     package_root: pathlib.Path = PCDSUTILS_PATH,
     prefix: str = "pcdsutils.",
 ) -> dict[str, ModuleType]:
-    """Find all pcdsdevices submodules, as a dictionary of name to module."""
+    """Find all pcdsutils submodules, as a dictionary of name to module."""
     modules = {}
     for item in pkgutil.walk_packages(path=[str(package_root)], prefix=prefix):
         try:
@@ -54,7 +54,6 @@ def find_all_classes(
             inspect.isclass(obj)
             and issubclass(obj, classes)
             and not obj.__module__.startswith("ophyd")
-            and not obj.__module__.startswith("pcdsdevices.tests")
             and not any(obj.__name__.startswith(part) for part in skip)
             and not any(obj.__module__.startswith(part) for part in skip)
         )
@@ -62,7 +61,7 @@ def find_all_classes(
     def sort_key(cls):
         return (cls.__module__, cls.__name__)
 
-    devices = [
+    classes = [
         obj
         for module in find_submodules(
             package_root,
@@ -71,7 +70,7 @@ def find_all_classes(
         for _, obj in inspect.getmembers(module, predicate=should_include)
     ]
 
-    return list(sorted(set(devices), key=sort_key))
+    return list(sorted(set(classes), key=sort_key))
 
 
 def find_all_callables(
@@ -101,7 +100,7 @@ def find_all_callables(
     def sort_key(obj):
         return (obj.__module__, obj.__name__)
 
-    devices = [
+    callables = [
         obj
         for module in find_submodules(
             package_root,
@@ -110,7 +109,7 @@ def find_all_callables(
         for _, obj in inspect.getmembers(module, predicate=should_include)
     ]
 
-    return list(sorted(set(devices), key=sort_key))
+    return list(sorted(set(callables), key=sort_key))
 
 
 skip_prefixes = [

--- a/docs/update_api_list.py
+++ b/docs/update_api_list.py
@@ -1,0 +1,173 @@
+"""
+Tool that generates the source for ``source/api.rst``.
+
+Borrows tools from the pcdsdevices test suite to enumerate modules, classes and
+callables.
+"""
+import importlib
+import inspect
+import logging
+import pathlib
+import pkgutil
+import sys
+from types import ModuleType
+from typing import Any, Callable, Optional
+
+MODULE_PATH = pathlib.Path(__file__).resolve().absolute()
+PCDSUTILS_PATH = MODULE_PATH.parents[1] / "pcdsutils"
+
+logger = logging.getLogger(__name__)
+
+
+def find_submodules(
+    package_root: pathlib.Path = PCDSUTILS_PATH,
+    prefix: str = "pcdsutils.",
+) -> dict[str, ModuleType]:
+    """Find all pcdsdevices submodules, as a dictionary of name to module."""
+    modules = {}
+    for item in pkgutil.walk_packages(path=[str(package_root)], prefix=prefix):
+        try:
+            modules[item.name] = sys.modules[item.name]
+        except KeyError:
+            # Submodules may not yet be imported; do that here.
+            try:
+                modules[item.name] = importlib.import_module(
+                    item.name, package=prefix.split(".")[0]
+                )
+            except Exception:
+                logger.exception("Failed to import %s", item.name)
+
+    return modules
+
+
+def find_all_classes(
+    classes,
+    package_root: pathlib.Path = PCDSUTILS_PATH,
+    prefix: str = "pcdsutils.",
+    skip_prefixes: Optional[list[str]] = None
+) -> list[Any]:
+    """Find all classes in pcdsutils and return them as a list."""
+    skip = skip_prefixes or []
+
+    def should_include(obj):
+        return (
+            inspect.isclass(obj)
+            and issubclass(obj, classes)
+            and not obj.__module__.startswith("ophyd")
+            and not obj.__module__.startswith("pcdsdevices.tests")
+            and not any(obj.__name__.startswith(part) for part in skip)
+            and not any(obj.__module__.startswith(part) for part in skip)
+        )
+
+    def sort_key(cls):
+        return (cls.__module__, cls.__name__)
+
+    devices = [
+        obj
+        for module in find_submodules(
+            package_root,
+            prefix,
+        ).values()
+        for _, obj in inspect.getmembers(module, predicate=should_include)
+    ]
+
+    return list(sorted(set(devices), key=sort_key))
+
+
+def find_all_callables(
+    package_root: pathlib.Path = PCDSUTILS_PATH,
+    prefix: str = "pcdsutils.",
+    skip_prefixes: Optional[list[str]] = None
+) -> list[Callable]:
+    """Find all callables in pcdsutils and return them as a list."""
+    skip = skip_prefixes or []
+
+    def should_include(obj):
+        try:
+            name = obj.__name__
+            module = obj.__module__
+        except AttributeError:
+            return False
+
+        return (
+            callable(obj)
+            and not inspect.isclass(obj)
+            and module.startswith(prefix)
+            and not name.startswith("_")
+            and not any(obj.__name__.startswith(part) for part in skip)
+            and not any(obj.__module__.startswith(part) for part in skip)
+        )
+
+    def sort_key(obj):
+        return (obj.__module__, obj.__name__)
+
+    devices = [
+        obj
+        for module in find_submodules(
+            package_root,
+            prefix,
+        ).values()
+        for _, obj in inspect.getmembers(module, predicate=should_include)
+    ]
+
+    return list(sorted(set(devices), key=sort_key))
+
+
+skip_prefixes = [
+    "pcdsutils.tests"
+]
+
+classes = find_all_classes(
+    (),
+    skip_prefixes=skip_prefixes,
+)
+
+callables = find_all_callables(
+    skip_prefixes=skip_prefixes,
+)
+
+modules = {
+    obj.__module__
+    for obj in list(classes) + list(callables)
+    if obj.__module__.startswith("pcdsutils.")
+}
+
+
+def create_api_list() -> list[str]:
+    """Create the API list with all classes and functions."""
+    output = [
+        "API",
+        "###",
+        "",
+    ]
+
+    for module_name in sorted(modules):
+        underline = "-" * len(module_name)
+        output.append(module_name)
+        output.append(underline)
+        output.append("")
+        module = sys.modules[module_name]
+        objects = [
+            obj
+            for obj in list(classes) + list(callables)
+            if obj.__module__ == module_name and hasattr(module, obj.__name__)
+        ]
+
+        if objects:
+            output.append(".. autosummary::")
+            output.append("    :toctree: generated")
+            output.append("")
+
+            for obj in sorted(objects, key=lambda obj: obj.__name__):
+                output.append(f"    {obj.__module__}.{obj.__name__}")
+
+            output.append("")
+
+    while output[-1] == "":
+        output.pop(-1)
+    return output
+
+
+if __name__ == "__main__":
+    output = create_api_list()
+    print("\n".join(output))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=45", "setuptools_scm[toml]>=6.2",]
 [project]
 classifiers = [ "Development Status :: 2 - Pre-Alpha", "Natural Language :: English", "Programming Language :: Python :: 3",]
 description = "PCDS Python Utilities"
-dynamic = [ "version", "readme", "dependencies", "optional-dependencies", "optional-dependencies",]
+dynamic = [ "version", "readme", "dependencies", "optional-dependencies",]
 keywords = []
 name = "pcdsutils"
 requires-python = ">=3.9"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add auto-generated API documentation and pre-release note scripts
* Unpin line-profiler for Python 3.11 support

## Motivation and Context
There are no docs here!

## How Has This Been Tested?
Locally built docs

## Where Has This Been Documented?
This is docs

## Screenshots (if appropriate):
<img width="1083" alt="image" src="https://github.com/pcdshub/pcdsutils/assets/5139267/06eca7c6-d51e-4915-84bb-2f75f82969e6">
<img width="1119" alt="image" src="https://github.com/pcdshub/pcdsutils/assets/5139267/30c70f94-1c5d-4ddc-aefa-7bc6bea66a9b">
