### PR TITLE
ENH: add filter for demoting pydm at exit error spam

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,12 @@
 <!--
 ## Screenshots (if appropriate):
 -->
+
+## Pre-merge checklist
+- [ ] Code works interactively
+- [ ] Code contains descriptive docstrings, including context and API
+- [ ] New/changed functions and methods are covered in the test suite where possible
+- [ ] Test suite passes locally
+- [ ] Test suite passes on GitHub Actions
+- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
+- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate

--- a/docs/source/upcoming_release_notes/81-enh_pydm_filter.rst
+++ b/docs/source/upcoming_release_notes/81-enh_pydm_filter.rst
@@ -1,0 +1,23 @@
+81 enh_pydm_filter
+##################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Add PydmDemotionFilter for making Pydm-based applications with logging
+  configurations less verbose at close when there are cleanup issues.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pcdsutils/log.py
+++ b/pcdsutils/log.py
@@ -871,7 +871,7 @@ class OphydCallbackExceptionDemoter(DemotionFilter):
     def should_demote(
         self,
         record: logging.LogRecord,
-        info: RecordInfo
+        info: RecordInfo,
     ) -> bool:
         """
         Return True if we should demote the record, False otherwise.
@@ -888,3 +888,36 @@ class OphydCallbackExceptionDemoter(DemotionFilter):
             for implementing this method.
         """
         return 'Subscription %s callback exception' in info.message
+
+
+class PydmDemotionFilter(DemotionFilter):
+    """
+    Demote verbose logs from pydm, particulary those that come at exit.
+
+    Currently, this demotes the "Unable to remove connection" logger exit
+    spam from "ERROR" to "DEBUG".
+
+    These can be caused by some poorly understood race conditions at program
+    close and are not useful for the end user.
+    """
+    default_logger = logging.getLogger("pydm.widgets.channel")
+
+    def should_demote(
+        self,
+        record: logging.LogRecord,
+        info: RecordInfo,
+    ) -> bool:
+        """
+        Return True if we should demote the record, False otherwise.
+
+        Demote if we see the "Unable to remove connection" error.
+
+        Parameters
+        ----------
+        record: logging.LogRecord
+            The record instance passed into the filter.
+        info: RecordInfo
+            The record info dataclass, which may be more convenient
+            for implementing this method.
+        """
+        return "Unable to remove connection" in info.message

--- a/pcdsutils/tests/test_logging.py
+++ b/pcdsutils/tests/test_logging.py
@@ -373,8 +373,7 @@ RuntimeError: wrapped C/C++ object of type Connection has been deleted
 
 @pytest.mark.parametrize(
     ("message", "should_demote"),
-    (msg1, True),
-    (msg2, False),
+    [(msg1, True), (msg2, False)],
 )
 def test_pydm_filter_conditions(
     message: str,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a filter for demoting this kind of error message from ERROR to DEBUG:
```
[2023-10-13 12:23:15,563] [ERROR   ] - Unable to remove connection for <PyDMChannel (ca://AT2L0:CALC:FILTER:02:Thickness)>
Traceback (most recent call last):
  File "/cds/home/z/zlentz/pydev/pydm/widgets/channel.py", line 164, in disconnect
    plugin.remove_connection(self, destroying=destroying)
  File "/cds/home/z/zlentz/pydev/pydm/data_plugins/plugin.py", line 323, in remove_connection
    self.connections[connection_id].deleteLater()
RuntimeError: wrapped C/C++ object of type Connection has been deleted
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These errors are raised and logged upon closing PyDM here, during the cleanup: https://github.com/slaclab/pydm/blob/4354f306e0cae15375204536673b8c551a2d2b67/pydm/widgets/channel.py#L166

These are likely important to resolve for application and test suite stability, but they are a bit too verbose for the user when it happens 20+ times at close. This filter will let us demote these on a case-by-case basis.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively in a simultaneous lucid PR, and added a test case that checks against a real world exception message (somewhat closely matches the real case, but technically not quite exactly)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate