### PR TITLE
BUG: Check for signal owner existence in WeakPartialMethodSlot teardown

### DIFF
--- a/docs/source/upcoming_release_notes/83-bug_weak_slot_disconn.rst
+++ b/docs/source/upcoming_release_notes/83-bug_weak_slot_disconn.rst
@@ -1,0 +1,22 @@
+83 bug_weak_slot_disconn
+########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Check ``signal_owner`` existence before attempting to disconnect a slot from its signal.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsutils/qt/callbacks.py
+++ b/pcdsutils/qt/callbacks.py
@@ -59,6 +59,7 @@ class WeakPartialMethodSlot:
         **kwargs
     ):
         self.signal = signal
+        self.signal_owner = weakref.ref(signal_owner)
         self.signal.connect(self._call, QtCore.Qt.QueuedConnection)
         self.method = weakref.WeakMethod(method)
         self._method_finalizer = weakref.finalize(
@@ -88,10 +89,12 @@ class WeakPartialMethodSlot:
         self.method = None
         self.partial_args = []
         self.partial_kwargs = {}
-        try:
-            self.signal.disconnect(self._call)
-        except Exception:
-            ...
+
+        if self.signal_owner():
+            try:
+                self.signal.disconnect(self._call)
+            except Exception:
+                ...
         self.signal = None
 
     def _call(self, *new_args, **new_kwargs):

--- a/pcdsutils/qt/callbacks.py
+++ b/pcdsutils/qt/callbacks.py
@@ -1,10 +1,13 @@
 """
 Helpers for callbacks
 """
+import logging
 import weakref
 from types import MethodType
 
-from qtpy import QtCore
+from qtpy import QtCore, sip
+
+logger = logging.getLogger(__name__)
 
 
 class WeakPartialMethodSlot:
@@ -90,11 +93,12 @@ class WeakPartialMethodSlot:
         self.partial_args = []
         self.partial_kwargs = {}
 
-        if self.signal_owner():
-            try:
+        owner = self.signal_owner()
+        try:
+            if (owner is not None) and not sip.isdeleted(owner):
                 self.signal.disconnect(self._call)
-            except Exception:
-                ...
+        except Exception as ex:
+            logger.debug(f'Unable to disconnect _call: {ex}')
         self.signal = None
 
     def _call(self, *new_args, **new_kwargs):


### PR DESCRIPTION
## Description
Keep a weakref to the signal owner and make sure it exists before trying to disconnect a slot from its signal.

## Motivation and Context
I'll be a bit more verbose here, since the diff isn't very descriptive.  Also for my own memory

In using this for https://github.com/pcdshub/atef/pull/226, I ran into all manner of memory allocation errors (segfaults, bus error, malloc).  While I seemed to get a variety of errors, I mostly got things like:
```
QObject::disconnect: No such signal QObject::currentTextChanged(QString)
Segmentation fault: 11
```

We are concerned primarily with the following method: [`WeakPartialMethodSlot._method_destroyed`](https://github.com/pcdshub/pcdsutils/blob/ea6b2e2fd0d7a7ace0879bfe2390f663c7368d4f/pcdsutils/qt/callbacks.py#L83-L96)

In `WeakPartialMethodSlot`, we set up two methods to run on QObject/signal destruction respectively.  Because I'm a dum child programmer, I set up a bunch of print statements and found I could get the following sequence:

```
>> method_destroyed: <bound PYQT_SIGNAL clicked of QToolButton object at 0x2bc4f28b0>
-->> signal_destroyed: <bound PYQT_SIGNAL clicked of QToolButton object at 0x2bc4f2670>
--<< signal_destroyed: <bound PYQT_SIGNAL clicked of QToolButton object at 0x2bc4f2670>
-->> signal_destroyed: <bound PYQT_SIGNAL clicked of QToolButton object at 0x2bc4f28b0>
--<< signal_destroyed: <bound PYQT_SIGNAL clicked of QToolButton object at 0x2bc4f28b0>
  disconnecting call from (None)
  caught an exception
  setting self.signal=None
<< finish method_destroyed: <bound PYQT_SIGNAL clicked of QToolButton object at 0x2bc4f28b0>
```

In words, within one of the `_method_destroyed` calls, the signal we are attempting to disconnect was dereferenced/destroyed (through WPMS's own `_signal_destroyed` method), even though we checked at the beginning of the method that it exists.  (Note the QToolButton IDs).  This always preceded a crash, but the method would finish (rather than the segfault occuring mid execution).  

Despite all this, introducing a check for the signal owner's existence seemed to solve the problem, and I'd like to move on

## How Has This Been Tested?
Interactively, using ATEF

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
