### PR TITLE
MNT/BLD: remove qtpyinheritance

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
   - prettytable
   - pypandoc
   - pyyaml
-  - qtpyinheritance
   - requests
 
 test:

--- a/pcdsutils/qt/__init__.py
+++ b/pcdsutils/qt/__init__.py
@@ -1,17 +1,7 @@
-from qtpyinheritance.properties import (PassthroughProperty,
-                                        ReadonlyPassthroughProperty,
-                                        forward_properties, forward_property,
-                                        get_qt_properties)
-
 from .designer_display import DesignerDisplay
 from .popbar import QPopBar
 
 __all__ = [
     "DesignerDisplay",
     "QPopBar",
-    "PassthroughProperty",
-    "ReadonlyPassthroughProperty",
-    "forward_properties",
-    "forward_property",
-    "get_qt_properties",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ prettytable
 pypandoc
 pyyaml
 qtpy
-qtpyinheritance
 requests
 typing_extensions


### PR DESCRIPTION
## Description
Remove qtpyinheritance, which needs some packaging updates and is not used within `pcdsutils` itself.

## Motivation and Context
Trying to get packages ready for py3.12.  `qtpyinheritance` needs to be moved off of versioneer and onto pyproject.toml framework, and may also be deprecated in the future due to disuse.

In `pcdsutils`, some `qtpyinheritance` members were exposed but never used.  If a user wanted to use `qtpyinheritance` they should probably just import that package directly

## How Has This Been Tested?
Will it build?

## Where Has This Been Documented?
This PR.  


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
