### PR TITLE
BUG/TST: update test behavior for combination of line_profiler 5.0.0 and python>=3.11

### DIFF
--- a/docs/source/upcoming_release_notes/87-bug_prof_naming.rst
+++ b/docs/source/upcoming_release_notes/87-bug_prof_naming.rst
@@ -1,0 +1,22 @@
+87 bug_prof_naming
+##################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- adjust test_profiler to account for new line_profiler 5.0.0
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsutils/tests/test_profile.py
+++ b/pcdsutils/tests/test_profile.py
@@ -3,8 +3,11 @@ Check some of the profiler internal utilities.
 """
 import logging
 import os.path
+import sys
 
+import line_profiler
 import pytest
+from packaging.version import Version
 
 from ..profile import (get_native_functions, get_submodules, is_native,
                        profiler_context)
@@ -59,8 +62,17 @@ def test_basic_profiler():
         for (file, lineno, func), stats in timings.items() if stats
     ]
     logger.debug(functions_profiled)
-    assert ('dummy_submodule.py', '__init__') in functions_profiled
+    print(functions_profiled)
+    # line_profiler 5.0.0 uses qualified name for py>=3.11
+    if (
+        sys.version_info.minor >= 11
+        and Version(line_profiler.__version__) >= Version("5.0.0")
+    ):
+        method_qualifier = "SomeClass."
+    else:
+        method_qualifier = ""
+    assert ('dummy_submodule.py', f'{method_qualifier}__init__') in functions_profiled
     assert ('dummy_submodule.py', 'some_function') in functions_profiled
-    assert ('dummy_submodule.py', 'method') in functions_profiled
-    assert ('dummy_submodule.py', 'cls_method') in functions_profiled
-    assert ('dummy_submodule.py', 'stat_method') in functions_profiled
+    assert ('dummy_submodule.py', f'{method_qualifier}method') in functions_profiled
+    assert ('dummy_submodule.py', f'{method_qualifier}cls_method') in functions_profiled
+    assert ('dummy_submodule.py', f'{method_qualifier}stat_method') in functions_profiled


### PR DESCRIPTION
## Description
`line_profiler` changed some of its behavior for output names with v5.0.0. See [release notes here](https://github.com/pyutils/line_profiler/releases/tag/v5.0.0)

If you are using python >=3.11 and this new lineprofiler, it'll use the "qualified name" for output information.

The check we do in these tests is a bit brittle, and remains that way.  But I didn't want to think too hard about this fix.

I suspect this doesn't change the actual profiling behavior, and the release notes assure us this version is backwards compatible with 4.x.x.

## Motivation and Context
Uncovered during new env tests and I want the tests to pass

## How Has This Been Tested?
Test passes in:
* pcds-6.1.0: (py3.12, line_profiler 5.0.0)
* pcds-6.0.1: (py3.12, line_profiler 4.2.0)
* pcds-5.9.1 + venv: (py3.9, line_profiler 5.0.0)

## Where Has This Been Documented?
This PR, and a comment

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
