### PR TITLE
BUG: do not call method before checking if it is None

### DIFF
--- a/docs/source/upcoming_release_notes/89-bug_wpms_call.rst
+++ b/docs/source/upcoming_release_notes/89-bug_wpms_call.rst
@@ -1,0 +1,22 @@
+89 bug_wpms_call
+################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Avoid calling the stored method in WeakPartialMethodSlot before checking if it is None
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsutils/qt/callbacks.py
+++ b/pcdsutils/qt/callbacks.py
@@ -107,7 +107,7 @@ class WeakPartialMethodSlot:
 
         Adds the received arguments to the stored partial arguments.
         """
-        method = self.method()
+        method = self.method
         if method is None:
             self._method_destroyed()
             return


### PR DESCRIPTION
## Description
Don't call the method stored in `WeakPartialMethodSlot` before checking if it is None

## Motivation and Context
I ran into this bug in superscore development, and was surprised we never hit it earlier.

## How Has This Been Tested?
N/A

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
