### PR TITLE
BUG: check if method has been cleaned up before calling

### DIFF
--- a/docs/source/upcoming_release_notes/90-bug_wpms_call.rst
+++ b/docs/source/upcoming_release_notes/90-bug_wpms_call.rst
@@ -1,0 +1,22 @@
+90 bug_wpms_call
+################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Avoid calling the stored method in WeakPartialMethodSlot before checking if it is None
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pcdsutils/qt/callbacks.py
+++ b/pcdsutils/qt/callbacks.py
@@ -108,7 +108,7 @@ class WeakPartialMethodSlot:
         Adds the received arguments to the stored partial arguments.
         """
         if self.method is None:
-            # we have already cleaned up already
+            # we have already cleaned up
             return
         method = self.method()
         if method is None:

--- a/pcdsutils/qt/callbacks.py
+++ b/pcdsutils/qt/callbacks.py
@@ -107,6 +107,9 @@ class WeakPartialMethodSlot:
 
         Adds the received arguments to the stored partial arguments.
         """
+        if self.method is None:
+            # we have already cleaned up already
+            return
         method = self.method()
         if method is None:
             self._method_destroyed()


### PR DESCRIPTION
## Description
Check if method has been removed before trying to call WeakPartialMethodSlot

## Motivation and Context
While I thought we had covered the relevant edge cases, it seems that I can sometimes hit a race condition where method is unassigned right before the call is made.

## How Has This Been Tested?
Interactively, though I removed WeakPartialMethodSlot use-cases in superscore that led to this in the end.

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
